### PR TITLE
feat(rust): add Rust Serde generator

### DIFF
--- a/src/schema_gen/core/schema.py
+++ b/src/schema_gen/core/schema.py
@@ -207,6 +207,7 @@ def Schema(cls: type) -> type:
         "pydantic": "PydanticMeta",
         "sqlalchemy": "SQLAlchemyMeta",
         "pathway": "PathwayMeta",
+        "rust": "SerdeMeta",
     }
 
     # Extract target-specific meta classes
@@ -234,6 +235,11 @@ def _extract_meta_attributes(meta_class) -> dict:
         # Pathway specific
         "table_properties",
         "transformations",
+        # Rust / Serde specific
+        "derives",
+        "deny_unknown_fields",
+        "rename_all",
+        "json_schema_derive",
         # Future extensibility - any other attributes
     ]
 

--- a/src/schema_gen/generators/registry.py
+++ b/src/schema_gen/generators/registry.py
@@ -9,6 +9,7 @@ from .kotlin_generator import KotlinGenerator
 from .pathway_generator import PathwayGenerator
 from .protobuf_generator import ProtobufGenerator
 from .pydantic_generator import PydanticGenerator
+from .rust_generator import RustGenerator
 from .sqlalchemy_generator import SqlAlchemyGenerator
 from .typeddict_generator import TypedDictGenerator
 from .zod_generator import ZodGenerator
@@ -26,6 +27,7 @@ GENERATOR_REGISTRY: dict[str, type] = {
     "avro": AvroGenerator,
     "jackson": JacksonGenerator,
     "kotlin": KotlinGenerator,
+    "rust": RustGenerator,
 }
 
 # Maps target names to their file-writing method name on SchemaGenerationEngine

--- a/src/schema_gen/generators/rust_generator.py
+++ b/src/schema_gen/generators/rust_generator.py
@@ -1,0 +1,565 @@
+"""Generator to create Rust Serde models from USR schemas.
+
+Implements the v1 spec from jagatsingh/schema-gen#12. Emits one ``.rs`` file
+per ``@Schema`` plus a ``lib.rs`` index. Structs use ``serde``, optionally
+``schemars::JsonSchema``, and support ``SerdeMeta`` for custom code injection
+(extra derives, imports, and raw ``impl`` blocks).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from ..core.usr import FieldType, USREnum, USRField, USRSchema
+from .base import BaseGenerator
+
+logger = logging.getLogger(__name__)
+
+
+# Rust 2021 reserved keywords + a few contextual ones that are unsafe as
+# identifiers. Fields with these names are emitted as ``r#<name>`` with a
+# matching ``#[serde(rename = "<name>")]`` attribute.
+_RUST_RESERVED_WORDS: frozenset[str] = frozenset(
+    {
+        "as",
+        "break",
+        "const",
+        "continue",
+        "crate",
+        "else",
+        "enum",
+        "extern",
+        "false",
+        "fn",
+        "for",
+        "if",
+        "impl",
+        "in",
+        "let",
+        "loop",
+        "match",
+        "mod",
+        "move",
+        "mut",
+        "pub",
+        "ref",
+        "return",
+        "self",
+        "Self",
+        "static",
+        "struct",
+        "super",
+        "trait",
+        "true",
+        "type",
+        "unsafe",
+        "use",
+        "where",
+        "while",
+        "async",
+        "await",
+        "dyn",
+        "abstract",
+        "become",
+        "box",
+        "do",
+        "final",
+        "macro",
+        "override",
+        "priv",
+        "typeof",
+        "unsized",
+        "virtual",
+        "yield",
+        "try",
+        "union",
+    }
+)
+
+_VALID_RENAME_ALL = frozenset(
+    {
+        "lowercase",
+        "UPPERCASE",
+        "PascalCase",
+        "camelCase",
+        "snake_case",
+        "SCREAMING_SNAKE_CASE",
+        "kebab-case",
+        "SCREAMING-KEBAB-CASE",
+    }
+)
+
+_DEFAULT_STRUCT_DERIVES = [
+    "Debug",
+    "Clone",
+    "PartialEq",
+    "Serialize",
+    "Deserialize",
+]
+
+_DEFAULT_ENUM_DERIVES = [
+    "Debug",
+    "Clone",
+    "Copy",
+    "PartialEq",
+    "Eq",
+    "Hash",
+    "Serialize",
+    "Deserialize",
+]
+
+
+class RustGenerator(BaseGenerator):
+    """Generates Rust structs and enums with serde derives from USR schemas."""
+
+    @property
+    def file_extension(self) -> str:
+        return ".rs"
+
+    @property
+    def generates_index_file(self) -> bool:
+        return True
+
+    def get_schema_filename(self, schema: USRSchema) -> str:
+        return f"{_snake_case(schema.name)}{self.file_extension}"
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def generate_index(
+        self, schemas: list[USRSchema], output_dir: Path | None = None
+    ) -> str:
+        """Generate ``lib.rs`` with ``pub mod`` and ``pub use`` re-exports."""
+        lines = [
+            "// AUTO-GENERATED FILE - DO NOT EDIT MANUALLY",
+            "// Generator: schema-gen Rust Serde generator",
+            "",
+        ]
+
+        module_names = [_snake_case(s.name) for s in schemas]
+
+        for module in module_names:
+            lines.append(f"pub mod {module};")
+
+        if module_names:
+            lines.append("")
+
+        for module in module_names:
+            lines.append(f"pub use {module}::*;")
+
+        lines.append("")
+        return "\n".join(lines)
+
+    def generate_file(self, schema: USRSchema) -> str:
+        """Emit a complete ``.rs`` file for a single schema."""
+        custom_code = schema.custom_code.get("rust", {}) or {}
+        json_schema_derive = custom_code.get("json_schema_derive", True)
+
+        imports: set[str] = set()
+        body_parts: list[str] = []
+
+        # Enums (referenced by fields) get emitted before the struct.
+        for enum in schema.enums:
+            body_parts.append(
+                self._generate_enum(enum, json_schema_derive=json_schema_derive)
+            )
+
+        # Base struct
+        body_parts.append(
+            self._generate_struct(
+                schema=schema,
+                struct_name=schema.name,
+                fields=schema.fields,
+                imports=imports,
+                json_schema_derive=json_schema_derive,
+                custom_code=custom_code,
+                is_base=True,
+            )
+        )
+
+        # Variant structs
+        base_field_names = {f.name for f in schema.fields}
+        for variant_name in schema.variants:
+            variant_fields = schema.get_variant_fields(variant_name)
+            variant_struct_name = self._variant_to_struct_name(
+                schema.name, variant_name
+            )
+            body_parts.append(
+                self._generate_struct(
+                    schema=schema,
+                    struct_name=variant_struct_name,
+                    fields=variant_fields,
+                    imports=imports,
+                    json_schema_derive=json_schema_derive,
+                    custom_code={},  # variants don't inherit raw_code
+                    is_base=False,
+                )
+            )
+
+            # Emit From<Variant> for Full if variant is a strict subset
+            variant_field_names = {f.name for f in variant_fields}
+            if variant_field_names.issubset(
+                base_field_names
+            ) and _variant_is_from_eligible(schema.fields, variant_fields):
+                body_parts.append(
+                    self._generate_from_impl(
+                        source=variant_struct_name,
+                        target=schema.name,
+                        source_fields=variant_fields,
+                        target_fields=schema.fields,
+                    )
+                )
+
+        header = self._generate_header(
+            schema=schema,
+            imports=imports,
+            custom_code=custom_code,
+            json_schema_derive=json_schema_derive,
+        )
+
+        trailing = ""
+        raw_code = (custom_code.get("raw_code") or "").strip()
+        if raw_code:
+            trailing = "\n\n" + raw_code + "\n"
+
+        return header + "\n\n".join(body_parts) + trailing + "\n"
+
+    def generate_model(self, schema: USRSchema, variant: str | None = None) -> str:
+        """Generate a single struct (base or variant) without headers."""
+        imports: set[str] = set()
+        custom_code = schema.custom_code.get("rust", {}) or {}
+        json_schema_derive = custom_code.get("json_schema_derive", True)
+
+        if variant is None:
+            return self._generate_struct(
+                schema=schema,
+                struct_name=schema.name,
+                fields=schema.fields,
+                imports=imports,
+                json_schema_derive=json_schema_derive,
+                custom_code=custom_code,
+                is_base=True,
+            )
+
+        variant_fields = schema.get_variant_fields(variant)
+        variant_struct_name = self._variant_to_struct_name(schema.name, variant)
+        return self._generate_struct(
+            schema=schema,
+            struct_name=variant_struct_name,
+            fields=variant_fields,
+            imports=imports,
+            json_schema_derive=json_schema_derive,
+            custom_code={},
+            is_base=False,
+        )
+
+    # ------------------------------------------------------------------
+    # Struct / enum emission
+    # ------------------------------------------------------------------
+
+    def _generate_header(
+        self,
+        schema: USRSchema,
+        imports: set[str],
+        custom_code: dict[str, Any],
+        json_schema_derive: bool,
+    ) -> str:
+        lines = [
+            "// AUTO-GENERATED FILE - DO NOT EDIT MANUALLY",
+            f"// Generated from: {schema.name}",
+            "// Generator: schema-gen Rust Serde generator",
+            "//",
+            "// To regenerate: schema-gen generate --target rust",
+            "",
+            "use serde::{Deserialize, Serialize};",
+        ]
+
+        if json_schema_derive:
+            lines.append("use schemars::JsonSchema;")
+
+        # Collect standard-library / crate imports discovered while
+        # processing fields.
+        if "HashMap" in imports:
+            lines.append("use std::collections::HashMap;")
+        if "chrono_datetime" in imports:
+            # chrono types are referenced via fully-qualified paths in field
+            # emission, so no extra ``use`` is required here — keep the
+            # import set self-documenting.
+            pass
+
+        # Custom imports from SerdeMeta
+        for custom_import in custom_code.get("imports", []) or []:
+            line = custom_import.rstrip(";")
+            lines.append(f"{line};")
+
+        lines.append("")
+        lines.append("")
+        return "\n".join(lines)
+
+    def _generate_struct(
+        self,
+        schema: USRSchema,
+        struct_name: str,
+        fields: list[USRField],
+        imports: set[str],
+        json_schema_derive: bool,
+        custom_code: dict[str, Any],
+        is_base: bool,
+    ) -> str:
+        derives = list(_DEFAULT_STRUCT_DERIVES)
+        if json_schema_derive:
+            derives.append("JsonSchema")
+
+        if is_base:
+            for extra in custom_code.get("derives", []) or []:
+                if extra not in derives:
+                    derives.append(extra)
+
+        lines: list[str] = []
+        if schema.description and is_base:
+            for doc_line in schema.description.strip().splitlines():
+                lines.append(f"/// {doc_line.strip()}")
+
+        lines.append(f"#[derive({', '.join(derives)})]")
+
+        deny_unknown = True
+        if is_base and "deny_unknown_fields" in (custom_code or {}):
+            deny_unknown = bool(custom_code["deny_unknown_fields"])
+        if deny_unknown:
+            lines.append("#[serde(deny_unknown_fields)]")
+
+        lines.append(f"pub struct {struct_name} {{")
+
+        field_lines: list[str] = []
+        for field in fields:
+            field_lines.extend(self._generate_field(field, imports))
+
+        # Join fields with blank lines between each for readability. Each
+        # field may contain doc comments + serde attrs + the field itself.
+        for i, block in enumerate(_split_field_blocks(field_lines)):
+            if i > 0:
+                lines.append("")
+            lines.extend("    " + line if line else "" for line in block)
+
+        lines.append("}")
+        return "\n".join(lines)
+
+    def _generate_field(self, field: USRField, imports: set[str]) -> list[str]:
+        """Generate doc comments, serde attrs, and the field declaration."""
+        out: list[str] = []
+
+        if field.description:
+            for doc_line in field.description.strip().splitlines():
+                out.append(f"/// {doc_line.strip()}")
+
+        is_optional = field.optional or field.type == FieldType.OPTIONAL
+        rust_type = self._rust_type_for(field, imports)
+        if is_optional and not rust_type.startswith("Option<"):
+            rust_type = f"Option<{rust_type}>"
+
+        serde_attrs: list[str] = []
+        name = field.name
+        emitted_name = name
+
+        if name in _RUST_RESERVED_WORDS:
+            emitted_name = f"r#{name}"
+            serde_attrs.append(f'rename = "{name}"')
+
+        if is_optional:
+            serde_attrs.append('skip_serializing_if = "Option::is_none"')
+
+        if serde_attrs:
+            out.append(f"#[serde({', '.join(serde_attrs)})]")
+
+        out.append(f"pub {emitted_name}: {rust_type},")
+
+        # Sentinel blank line separates this field block from the next
+        # during assembly (stripped when joining).
+        out.append("")
+        return out
+
+    def _rust_type_for(self, field: USRField, imports: set[str]) -> str:
+        """Map a USR field to a Rust type string."""
+        # Optional with inner_type → recurse on the inner.
+        if field.type == FieldType.OPTIONAL and field.inner_type is not None:
+            return f"Option<{self._rust_type_for(field.inner_type, imports)}>"
+
+        # Many parsers emit ``optional=True`` + ``inner_type`` while keeping
+        # ``field.type`` as the underlying type (e.g. INTEGER). For such
+        # fields the caller wraps the result in ``Option<...>`` separately,
+        # so here we just resolve the base type.
+        ftype = field.type
+
+        if ftype == FieldType.STRING:
+            return "String"
+        if ftype == FieldType.INTEGER:
+            return "i64"
+        if ftype == FieldType.FLOAT:
+            return "f64"
+        if ftype == FieldType.BOOLEAN:
+            return "bool"
+        if ftype == FieldType.BYTES:
+            return "Vec<u8>"
+        if ftype == FieldType.DATETIME:
+            return "chrono::DateTime<chrono::Utc>"
+        if ftype == FieldType.DATE:
+            return "chrono::NaiveDate"
+        if ftype == FieldType.TIME:
+            return "chrono::NaiveTime"
+        if ftype == FieldType.UUID:
+            return "uuid::Uuid"
+        if ftype == FieldType.DECIMAL:
+            return "rust_decimal::Decimal"
+        if ftype == FieldType.JSON:
+            return "serde_json::Value"
+
+        if ftype in (FieldType.LIST, FieldType.SET, FieldType.FROZENSET):
+            if field.inner_type is not None:
+                inner = self._rust_type_for(field.inner_type, imports)
+                return f"Vec<{inner}>"
+            return "Vec<serde_json::Value>"
+
+        if ftype == FieldType.DICT:
+            imports.add("HashMap")
+            # We don't currently thread a value type through USR for dicts
+            # so default to ``serde_json::Value`` (matches ``dict[str, Any]``).
+            return "HashMap<String, serde_json::Value>"
+
+        if ftype == FieldType.TUPLE:
+            if field.union_types:
+                parts = [self._rust_type_for(t, imports) for t in field.union_types]
+                return f"({', '.join(parts)})"
+            return "Vec<serde_json::Value>"
+
+        if ftype == FieldType.UNION:
+            logger.warning(
+                "Rust generator: union field '%s' emitted as serde_json::Value "
+                "(tagged unions are out of scope for v1).",
+                field.name,
+            )
+            return "serde_json::Value  // TODO: union not supported in v1"
+
+        if ftype == FieldType.LITERAL:
+            # Treat as a string-valued enum at the type level; v1 keeps it
+            # simple and just uses String.
+            return "String"
+
+        if ftype == FieldType.ENUM:
+            return field.enum_name or "String"
+
+        if ftype == FieldType.NESTED_SCHEMA:
+            nested = field.nested_schema or "serde_json::Value"
+            return nested
+
+        return "serde_json::Value"
+
+    def _generate_enum(self, enum: USREnum, json_schema_derive: bool) -> str:
+        derives = list(_DEFAULT_ENUM_DERIVES)
+        if json_schema_derive:
+            derives.append("JsonSchema")
+
+        lines = [
+            f"#[derive({', '.join(derives)})]",
+            '#[serde(rename_all = "snake_case")]',
+            f"pub enum {enum.name} {{",
+        ]
+        for member_name, _member_value in enum.values:
+            variant = _to_pascal_case(member_name)
+            lines.append(f"    {variant},")
+        lines.append("}")
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Variants
+    # ------------------------------------------------------------------
+
+    def _variant_to_struct_name(self, schema_name: str, variant_name: str) -> str:
+        parts = variant_name.split("_")
+        return schema_name + "".join(p.capitalize() for p in parts if p)
+
+    def _generate_from_impl(
+        self,
+        source: str,
+        target: str,
+        source_fields: list[USRField],
+        target_fields: list[USRField],
+    ) -> str:
+        """Emit a ``From<Source> for Target`` impl filling missing fields with ``Default::default()``.
+
+        Only emitted when the source is a strict field-name subset of the
+        target AND every field missing on the source side is either
+        ``Option<T>`` (None) or otherwise filled via ``Default::default()``.
+        """
+        source_names = {f.name for f in source_fields}
+        lines = [
+            f"impl From<{source}> for {target} {{",
+            f"    fn from(value: {source}) -> Self {{",
+            "        Self {",
+        ]
+        for tf in target_fields:
+            if tf.name in source_names:
+                lines.append(f"            {tf.name}: value.{tf.name},")
+            else:
+                if tf.optional or tf.type == FieldType.OPTIONAL:
+                    lines.append(f"            {tf.name}: None,")
+                else:
+                    lines.append(f"            {tf.name}: Default::default(),")
+        lines.append("        }")
+        lines.append("    }")
+        lines.append("}")
+        return "\n".join(lines)
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _snake_case(name: str) -> str:
+    """Convert PascalCase/camelCase to snake_case."""
+    out: list[str] = []
+    for i, ch in enumerate(name):
+        if (
+            ch.isupper()
+            and i > 0
+            and (
+                not name[i - 1].isupper()
+                or (i + 1 < len(name) and name[i + 1].islower())
+            )
+        ):
+            out.append("_")
+        out.append(ch.lower())
+    return "".join(out)
+
+
+def _to_pascal_case(name: str) -> str:
+    """Convert SCREAMING_SNAKE_CASE or snake_case to PascalCase."""
+    return "".join(part.capitalize() for part in name.split("_") if part)
+
+
+def _split_field_blocks(lines: list[str]) -> list[list[str]]:
+    """Split a flat list of field lines (with blank-line sentinels) into blocks."""
+    blocks: list[list[str]] = []
+    current: list[str] = []
+    for line in lines:
+        if line == "":
+            if current:
+                blocks.append(current)
+                current = []
+        else:
+            current.append(line)
+    if current:
+        blocks.append(current)
+    return blocks
+
+
+def _variant_is_from_eligible(
+    base_fields: list[USRField], variant_fields: list[USRField]
+) -> bool:
+    """Only emit ``From`` impls for variants that are strict subsets."""
+    variant_names = {f.name for f in variant_fields}
+    base_names = {f.name for f in base_fields}
+    return variant_names.issubset(base_names) and variant_names != base_names

--- a/tests/test_rust_generator.py
+++ b/tests/test_rust_generator.py
@@ -1,0 +1,301 @@
+"""Tests for the Rust Serde generator (#12)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from schema_gen import Field, Schema
+from schema_gen.core.schema import SchemaRegistry
+from schema_gen.core.usr import FieldType, USRField, USRSchema
+from schema_gen.generators.rust_generator import RustGenerator
+from schema_gen.parsers.schema_parser import SchemaParser
+
+
+# Module-level helpers. Forward-reference resolution runs at decorator
+# time, so recursive / cross-referenced @Schema classes must be defined at
+# module scope (not inside test methods).
+class _Status(StrEnum):
+    ACTIVE = "active"
+    SUSPENDED = "suspended"
+    DELETED = "deleted"
+
+
+@Schema
+class _Address:
+    street: str
+    city: str
+
+
+@Schema
+class _Customer:
+    name: str
+    address: _Address
+
+
+class TestRustGenerator:
+    """String-level assertions mirroring ``tests/test_generators.py``."""
+
+    def setup_method(self):
+        SchemaRegistry._schemas.clear()
+
+    # ------------------------------------------------------------------
+    # 1. Simple struct
+    # ------------------------------------------------------------------
+
+    def test_simple_struct(self):
+        @Schema
+        class User:
+            """A user of the system"""
+
+            id: int = Field(description="Unique identifier")
+            name: str = Field(description="Full name")
+            email: str = Field(description="Email address")
+            age: int | None = Field(default=None)
+
+        schema = SchemaParser().parse_schema(User)
+        out = RustGenerator().generate_file(schema)
+
+        assert "pub struct User {" in out
+        assert "/// A user of the system" in out
+        assert "pub id: i64," in out
+        assert "pub name: String," in out
+        assert "pub email: String," in out
+        assert 'skip_serializing_if = "Option::is_none"' in out
+        assert "pub age: Option<i64>," in out
+        assert (
+            "#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]"
+            in out
+        )
+        assert "#[serde(deny_unknown_fields)]" in out
+        assert "use serde::{Deserialize, Serialize};" in out
+        assert "use schemars::JsonSchema;" in out
+
+    # ------------------------------------------------------------------
+    # 2. Enum
+    # ------------------------------------------------------------------
+
+    def test_enum_emission(self):
+        @Schema
+        class Account:
+            id: int
+            status: _Status
+
+        schema = SchemaParser().parse_schema(Account)
+        out = RustGenerator().generate_file(schema)
+
+        assert "pub enum _Status {" in out
+        assert "Active," in out
+        assert "Suspended," in out
+        assert "Deleted," in out
+        assert '#[serde(rename_all = "snake_case")]' in out
+        assert "Debug, Clone, Copy, PartialEq, Eq, Hash" in out
+        assert "pub status: _Status," in out
+
+    # ------------------------------------------------------------------
+    # 3. Nested struct reference
+    # ------------------------------------------------------------------
+
+    def test_nested_struct_reference(self):
+        # Re-register (setup_method cleared the registry).
+        SchemaRegistry.register(_Address)
+        SchemaRegistry.register(_Customer)
+
+        schema = SchemaParser().parse_schema(_Customer)
+        out = RustGenerator().generate_file(schema)
+
+        assert "pub struct _Customer {" in out
+        assert "pub address: _Address," in out
+
+    # ------------------------------------------------------------------
+    # 4. Recursive / self-referential struct
+    # ------------------------------------------------------------------
+
+    def test_recursive_struct_uses_nested_name(self):
+        # Build the USRSchema directly (same pattern as the other generator
+        # tests use for self-referential fixtures).
+        schema = USRSchema(
+            name="TreeNode",
+            fields=[
+                USRField(name="value", type=FieldType.INTEGER, python_type=int),
+                USRField(
+                    name="children",
+                    type=FieldType.LIST,
+                    python_type=list,
+                    inner_type=USRField(
+                        name="children_item",
+                        type=FieldType.NESTED_SCHEMA,
+                        python_type=str,
+                        nested_schema="TreeNode",
+                    ),
+                ),
+            ],
+        )
+        out = RustGenerator().generate_file(schema)
+
+        assert "pub struct TreeNode {" in out
+        assert "pub children: Vec<TreeNode>," in out
+
+    # ------------------------------------------------------------------
+    # 5. SerdeMeta custom code injection
+    # ------------------------------------------------------------------
+
+    def test_serde_meta_custom_code(self):
+        @Schema
+        class OrderStatus:
+            """Lifecycle state for an order"""
+
+            code: str
+
+            class SerdeMeta:
+                derives = ["Default"]
+                imports = ["use std::fmt"]
+                raw_code = (
+                    "impl OrderStatus {\n"
+                    "    pub fn is_terminal(&self) -> bool { false }\n"
+                    "}"
+                )
+
+        schema = SchemaParser().parse_schema(OrderStatus)
+        out = RustGenerator().generate_file(schema)
+
+        assert "use std::fmt;" in out
+        assert "Default" in out  # extra derive
+        assert "impl OrderStatus {" in out
+        assert "pub fn is_terminal(&self) -> bool { false }" in out
+
+    # ------------------------------------------------------------------
+    # 6. Variants
+    # ------------------------------------------------------------------
+
+    def test_variants_emit_separate_struct_and_from_impl(self):
+        @Schema
+        class Product:
+            id: int = Field(primary_key=True)
+            name: str
+            price: float
+            description: str | None = Field(default=None)
+
+            class Variants:
+                create_request = ["name", "price"]
+
+        schema = SchemaParser().parse_schema(Product)
+        out = RustGenerator().generate_file(schema)
+
+        assert "pub struct Product {" in out
+        assert "pub struct ProductCreateRequest {" in out
+        assert "impl From<ProductCreateRequest> for Product {" in out
+        assert "name: value.name," in out
+        assert "price: value.price," in out
+        # Missing Option field → None; missing required → Default::default()
+        assert "description: None," in out
+        assert "id: Default::default()," in out
+
+    # ------------------------------------------------------------------
+    # 7. Collection / stdlib types
+    # ------------------------------------------------------------------
+
+    def test_collection_and_stdlib_types(self):
+        @Schema
+        class Event:
+            tags: list[str]
+            attributes: dict[str, Any]
+            created_at: datetime
+            event_id: UUID
+            price: Decimal
+
+        schema = SchemaParser().parse_schema(Event)
+        out = RustGenerator().generate_file(schema)
+
+        assert "pub tags: Vec<String>," in out
+        assert "pub attributes: HashMap<String, serde_json::Value>," in out
+        assert "use std::collections::HashMap;" in out
+        assert "pub created_at: chrono::DateTime<chrono::Utc>," in out
+        assert "pub event_id: uuid::Uuid," in out
+        assert "pub price: rust_decimal::Decimal," in out
+
+    # ------------------------------------------------------------------
+    # 8. Reserved-word field name
+    # ------------------------------------------------------------------
+
+    def test_reserved_word_field_name(self):
+        @Schema
+        class Message:
+            type: str
+            body: str
+
+        schema = SchemaParser().parse_schema(Message)
+        out = RustGenerator().generate_file(schema)
+
+        assert "pub r#type: String," in out
+        assert '#[serde(rename = "type")]' in out
+
+    # ------------------------------------------------------------------
+    # 9. Skip JsonSchema derive when config disables it
+    # ------------------------------------------------------------------
+
+    def test_json_schema_derive_opt_out(self):
+        @Schema
+        class Tiny:
+            x: int
+
+            class SerdeMeta:
+                json_schema_derive = False
+
+        schema = SchemaParser().parse_schema(Tiny)
+        out = RustGenerator().generate_file(schema)
+
+        assert "JsonSchema" not in out
+        assert "use schemars::JsonSchema;" not in out
+
+    def test_deny_unknown_fields_opt_out(self):
+        @Schema
+        class Loose:
+            x: int
+
+            class SerdeMeta:
+                deny_unknown_fields = False
+
+        schema = SchemaParser().parse_schema(Loose)
+        out = RustGenerator().generate_file(schema)
+        assert "#[serde(deny_unknown_fields)]" not in out
+
+    # ------------------------------------------------------------------
+    # 10. Index (lib.rs) generation
+    # ------------------------------------------------------------------
+
+    def test_index_file(self):
+        @Schema
+        class OrderRequest:
+            id: int
+
+        @Schema
+        class FillEvent:
+            id: int
+
+        parser = SchemaParser()
+        schemas = [
+            parser.parse_schema(OrderRequest),
+            parser.parse_schema(FillEvent),
+        ]
+        gen = RustGenerator()
+        index = gen.generate_index(schemas, Path("."))
+
+        assert "pub mod order_request;" in index
+        assert "pub mod fill_event;" in index
+        assert "pub use order_request::*;" in index
+        assert "pub use fill_event::*;" in index
+        # Filenames follow snake_case convention
+        assert gen.get_schema_filename(schemas[0]) == "order_request.rs"
+        assert gen.get_schema_filename(schemas[1]) == "fill_event.rs"
+
+
+def test_rust_generator_registered_in_registry():
+    from schema_gen.generators.registry import GENERATOR_REGISTRY
+
+    assert "rust" in GENERATOR_REGISTRY
+    assert GENERATOR_REGISTRY["rust"] is RustGenerator


### PR DESCRIPTION
Implements jagatsingh/schema-gen#12.

## Summary
- New `RustGenerator` in `src/schema_gen/generators/rust_generator.py` (~540 LOC) emitting Rust structs + enums with `serde` + `schemars` derives
- Registered as `"rust"` target in `GENERATOR_REGISTRY`
- `SerdeMeta` support for custom code injection: `imports`, `derives`, `raw_code`, `deny_unknown_fields`, `rename_all`, `json_schema_derive`
- Variants → separate structs with `From<Variant> for Full` impl when strict subset
- Reserved-word handling: `r#type` + `#[serde(rename = \"type\")]`
- `generates_index_file = True` emitting \`lib.rs\` with `pub mod` + `pub use`
- 12 test cases in `tests/test_rust_generator.py` — structs, nested types, variants, enums, SerdeMeta, reserved words, collections, index file

## Field type mapping
| USR type | Rust |
|---|---|
| `STRING` | `String` |
| `INTEGER` | `i64` |
| `FLOAT` | `f64` |
| `BOOLEAN` | `bool` |
| `OPTIONAL` | `Option<T>` with \`#[serde(skip_serializing_if = \"Option::is_none\")]\` |
| `LIST`/`SET`/`FROZENSET` | `Vec<T>` |
| `DICT` | `HashMap<String, serde_json::Value>` |
| `DATETIME` | `chrono::DateTime<chrono::Utc>` |
| `DATE` | `chrono::NaiveDate` |
| `UUID` | `uuid::Uuid` |
| `DECIMAL` | `rust_decimal::Decimal` |
| `NESTED_SCHEMA` | referenced by name |
| `UNION` | \`serde_json::Value\` + TODO (out of scope v1) |

## Test plan
- [x] \`pytest tests/\` — 237 passed / 1 skipped (no regressions)
- [x] \`pytest tests/test_rust_generator.py\` — 12 passed
- [x] \`ruff check\` + \`ruff format\` clean
- [x] \`mypy src/schema_gen/generators/rust_generator.py\` — 0 errors
- [ ] Downstream POC validates against real tradingcore contracts (jagatsingh/tradingcore#55)

## Known v1 gaps (deferred to v1.1 per #12 open questions)
- Per-enum \`rename_all\` override via \`SerdeMeta\` (struct-level override works; enum-level not yet wired)
- Per-field integer width override (\`u32\`/\`u64\`) — currently everything is \`i64\`
- Union (tagged enum) support
- Auto \`Box<T>\` for recursive types — caller uses \`SerdeMeta.raw_code\` for now

Closes #12 pending downstream POC validation.