### PR TITLE
fix: make base Cargo deps overridable via extra_deps

### DIFF
--- a/src/schema_gen/generators/rust_generator.py
+++ b/src/schema_gen/generators/rust_generator.py
@@ -1053,15 +1053,22 @@ def _render_cargo_toml(rust_cfg: dict[str, Any]) -> str:
         'path = "lib.rs"',
         "",
         "[dependencies]",
-        'serde = { version = "1", features = ["derive"] }',
-        'chrono = { version = "0.4", features = ["serde"] }',
-        'schemars = "0.8"',
     ]
+    # Default base deps — overridable via extra_deps
+    base_deps = {
+        "serde": '{ version = "1", features = ["derive"] }',
+        "chrono": '{ version = "0.4", features = ["serde"] }',
+        "schemars": '"0.8"',
+    }
+    for crate, default_spec in base_deps.items():
+        if crate not in extra_deps:
+            lines.append(f"{crate} = {default_spec}")
     for crate, spec in sorted(extra_deps.items()):
-        if isinstance(spec, str):
+        if isinstance(spec, str) and not spec.lstrip().startswith("{"):
+            # Simple version string — wrap in quotes
             lines.append(f'{crate} = "{spec}"')
         else:
-            # Assume a pre-formatted inline table string provided by the user.
+            # Inline table or pre-formatted TOML — emit verbatim
             lines.append(f"{crate} = {spec}")
     lines.append("")
     return "\n".join(lines)


### PR DESCRIPTION
## Summary
- serde, chrono, and schemars were hardcoded in the generated Cargo.toml
- Now they can be overridden through the `extra_deps` config key, allowing consumers to align versions with their workspace (e.g., schemars 1.0 instead of 0.8)
- Fixes inline table quoting — strings starting with `{` are emitted verbatim instead of being double-quoted

## Test plan
- [x] Verified with tradingcore contracts: `schemars = { version = "1", features = ["chrono04"] }` emitted correctly
- [x] `cargo check` passes on generated workspace member
- [x] Existing tests unaffected (default deps unchanged when no `extra_deps` specified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)