### PR TITLE
feat: schema-gen diff — breaking change detection

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -147,6 +147,77 @@ schema-gen install-hooks --no-install-pre-commit
 - Installs the hooks in your git repository
 - Sets up automatic generation on schema changes
 
+### `schema-gen diff`
+
+Detect breaking changes by comparing current JSON Schema output against a baseline (git branch, tag, commit, or directory snapshot). Inspired by [buf breaking](https://buf.build/docs/breaking/rules/).
+
+```bash
+schema-gen diff [OPTIONS]
+```
+
+**Options:**
+- `--against TEXT` - **(required)** Baseline reference:
+  - `.git#branch=main` — compare against a git branch
+  - `.git#tag=v1.0.0` — compare against a git tag
+  - `.git#commit=abc123` — compare against a specific commit
+  - `/path/to/snapshot/` — compare against a directory of JSON Schema files
+- `--level [WIRE|WIRE_JSON|SOURCE]` - Strictness level (default: `WIRE_JSON`)
+- `--format [text|json]` - Output format (default: `text`)
+- `--ignore TEXT` - Suppress a specific rule (repeatable)
+- `-c, --config TEXT` - Path to config file (default: `.schema-gen.config.py`)
+
+**Prerequisites:**
+- `jsonschema` must be in your configured `targets`
+- JSON Schema output must be committed to version control
+
+**Examples:**
+```bash
+# Compare against main branch
+schema-gen diff --against .git#branch=main
+
+# Use WIRE level (serialization-breaking only)
+schema-gen diff --against .git#tag=v1.0.0 --level WIRE
+
+# JSON output for CI parsing
+schema-gen diff --against .git#branch=main --format json
+
+# Suppress a known intentional break
+schema-gen diff --against .git#branch=main --ignore FIELD_NO_DELETE
+```
+
+**Strictness levels:**
+
+| Level | What it checks |
+|-------|---------------|
+| `WIRE` | Serialization-breaking: deleted types/fields, type changes, narrowed types, new required fields, removed enum variants |
+| `WIRE_JSON` | WIRE + JSON key identity: field renames, enum value name changes |
+| `SOURCE` | Reserved for future use (field ordering, namespace changes) |
+
+**Rules:**
+
+| Rule | Level | Description |
+|------|-------|-------------|
+| `TYPE_NO_DELETE` | WIRE | Schema type was removed |
+| `FIELD_NO_DELETE` | WIRE | Field was removed from a schema |
+| `FIELD_SAME_TYPE` | WIRE | Field type changed incompatibly |
+| `FIELD_TYPE_NARROWED` | WIRE | Numeric type narrowed (e.g. number to integer) |
+| `FIELD_REQUIRED_ADDED` | WIRE | New required field added |
+| `ENUM_VALUE_NO_DELETE` | WIRE | Enum variant was removed |
+| `FIELD_SAME_NAME` | WIRE_JSON | Field appears to have been renamed |
+| `ENUM_VALUE_SAME_NAME` | WIRE_JSON | Enum value changed at same position |
+
+**Always safe (never flagged):**
+- Adding a new optional field
+- Adding a new enum variant
+- Adding a new schema type
+- Adding a new schema file
+- Widening a numeric type (integer to number)
+
+**Exit codes:**
+- `0` — No breaking changes
+- `1` — Breaking changes detected
+- `2` — Tool error (e.g. baseline not found)
+
 ## Configuration Priority
 
 Schema Gen uses the following priority order for configuration:
@@ -210,6 +281,18 @@ git diff --exit-code generated/ || {
     echo "Generated models are out of date"
     exit 1
 }
+```
+
+### Breaking Change Detection
+```bash
+# Check for breaking schema changes on every PR
+schema-gen diff --against .git#branch=main
+
+# Use in CI with JSON output
+schema-gen diff --against .git#branch=main --format json
+
+# Allow a known intentional break
+schema-gen diff --against .git#branch=main --ignore FIELD_NO_DELETE
 ```
 
 ### Multi-Environment Setup

--- a/src/schema_gen/cli/main.py
+++ b/src/schema_gen/cli/main.py
@@ -12,7 +12,7 @@ from ..core.generator import create_generation_engine
 from ..diff.baseline import BaselineError, load_baseline, load_current
 from ..diff.comparator import compare_schemas
 from ..diff.formatter import format_json, format_text
-from ..diff.rules import StrictnessLevel
+from ..diff.rules import RuleId, StrictnessLevel
 
 # Pattern to match timestamp lines across all generators
 _TIMESTAMP_RE = re.compile(r"^.*Generated at:.*$", re.MULTILINE)
@@ -569,6 +569,17 @@ def diff(against, level, fmt, ignore_rules, config_path):
       2   Tool error
     """
     try:
+        # Validate --ignore values early so typos are caught before comparison.
+        valid_rule_names = {r.value for r in RuleId}
+        for rule_name in ignore_rules:
+            if rule_name not in valid_rule_names:
+                click.echo(
+                    f"Unknown rule: {rule_name}. "
+                    f"Valid rules: {sorted(valid_rule_names)}",
+                    err=True,
+                )
+                raise SystemExit(2)
+
         engine = create_generation_engine(config_path)
         output_dir = engine.config.output_dir
 

--- a/src/schema_gen/cli/main.py
+++ b/src/schema_gen/cli/main.py
@@ -9,6 +9,10 @@ from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
 from ..core.generator import create_generation_engine
+from ..diff.baseline import BaselineError, load_baseline, load_current
+from ..diff.comparator import compare_schemas
+from ..diff.formatter import format_json, format_text
+from ..diff.rules import StrictnessLevel
 
 # Pattern to match timestamp lines across all generators
 _TIMESTAMP_RE = re.compile(r"^.*Generated at:.*$", re.MULTILINE)
@@ -515,6 +519,87 @@ def install_hooks(install_pre_commit):
         except FileNotFoundError:
             click.echo("❌ pip not found")
             click.echo("💡 Install pre-commit manually and run: pre-commit install")
+
+
+@main.command()
+@click.option(
+    "--against",
+    required=True,
+    help=(
+        "Baseline reference: .git#branch=main, .git#tag=v1.0.0, "
+        ".git#commit=abc123, or /path/to/snapshot/"
+    ),
+)
+@click.option(
+    "--level",
+    type=click.Choice(["WIRE", "WIRE_JSON", "SOURCE"], case_sensitive=False),
+    default="WIRE_JSON",
+    help="Strictness level [default: WIRE_JSON]",
+)
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    help="Output format [default: text]",
+)
+@click.option(
+    "--ignore",
+    "ignore_rules",
+    multiple=True,
+    help="Suppress a specific rule (repeatable)",
+)
+@click.option(
+    "--config",
+    "-c",
+    "config_path",
+    help="Path to config file",
+    default=".schema-gen.config.py",
+)
+def diff(against, level, fmt, ignore_rules, config_path):
+    """Compare schemas against a baseline to detect breaking changes.
+
+    Requires 'jsonschema' in your configured targets with generated output
+    committed to version control.
+
+    \b
+    EXIT CODES:
+      0   No breaking changes
+      1   Breaking changes detected
+      2   Tool error
+    """
+    try:
+        engine = create_generation_engine(config_path)
+        output_dir = engine.config.output_dir
+
+        strictness = StrictnessLevel(level.upper())
+        old_schemas = load_baseline(against, output_dir)
+        new_schemas = load_current(output_dir)
+
+        violations = compare_schemas(
+            old_schemas,
+            new_schemas,
+            level=strictness,
+            ignore=list(ignore_rules),
+        )
+
+        if violations:
+            if fmt == "json":
+                click.echo(format_json(violations))
+            else:
+                click.echo(format_text(violations))
+            raise SystemExit(1)
+        else:
+            click.echo("No breaking changes detected.")
+
+    except BaselineError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        raise SystemExit(2) from exc
+    except SystemExit:
+        raise
+    except Exception as exc:
+        click.echo(f"Error: {exc}", err=True)
+        raise SystemExit(2) from exc
 
 
 if __name__ == "__main__":

--- a/src/schema_gen/diff/__init__.py
+++ b/src/schema_gen/diff/__init__.py
@@ -1,0 +1,14 @@
+"""Breaking change detection for schema-gen schemas."""
+
+from .comparator import compare_schemas
+from .formatter import format_json, format_text
+from .rules import RuleId, StrictnessLevel, Violation
+
+__all__ = [
+    "RuleId",
+    "StrictnessLevel",
+    "Violation",
+    "compare_schemas",
+    "format_text",
+    "format_json",
+]

--- a/src/schema_gen/diff/baseline.py
+++ b/src/schema_gen/diff/baseline.py
@@ -1,0 +1,192 @@
+"""Load baseline and current JSON Schema files for comparison."""
+
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+class BaselineError(Exception):
+    """Raised when the baseline cannot be loaded."""
+
+
+_GIT_REF_RE = re.compile(r"^\.git#(?P<kind>branch|tag|commit)=(?P<value>.+)$")
+
+
+def _parse_git_ref(against: str) -> str:
+    """Extract the git ref from an ``--against`` value.
+
+    Accepted formats::
+
+        .git#branch=main
+        .git#tag=v1.0.0
+        .git#commit=abc123
+
+    Returns the bare ref string (e.g. ``main``, ``v1.0.0``, ``abc123``).
+
+    Raises:
+        BaselineError: If the format is not recognised.
+    """
+    match = _GIT_REF_RE.match(against)
+    if not match:
+        raise BaselineError(
+            f"Invalid git baseline format: {against!r}. "
+            "Expected .git#branch=<name>, .git#tag=<name>, or .git#commit=<hash>"
+        )
+    return match.group("value")
+
+
+def _git_show(ref: str, path: str) -> str | None:
+    """Run ``git show <ref>:<path>`` and return the content, or None if not found.
+
+    Returns None when the file does not exist at the given ref.
+    Raises :class:`BaselineError` for unexpected git failures.
+    """
+    result = subprocess.run(
+        ["git", "show", f"{ref}:{path}"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return result.stdout
+    # "does not exist" or "exists on disk, but not in" → file not found at ref.
+    if "does not exist" in result.stderr or "exists on disk" in result.stderr:
+        return None
+    # Any other error (bad ref, corrupt repo) should surface.
+    raise BaselineError(f"git show {ref}:{path} failed: {result.stderr.strip()}")
+
+
+def _discover_current_json_files(jsonschema_dir: Path) -> list[str]:
+    """Return sorted list of ``*.json`` filenames in *jsonschema_dir*."""
+    if not jsonschema_dir.is_dir():
+        return []
+    return sorted(p.name for p in jsonschema_dir.glob("*.json"))
+
+
+def _discover_baseline_json_files(ref: str, jsonschema_dir: Path) -> list[str]:
+    """Return sorted list of ``*.json`` filenames that exist at *ref* in git.
+
+    Uses ``git ls-tree`` to enumerate files at the baseline ref, catching
+    deletions that ``_discover_current_json_files`` would miss.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "ls-tree", "--name-only", ref, str(jsonschema_dir) + "/"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        return []
+
+    filenames: list[str] = []
+    for line in result.stdout.strip().splitlines():
+        name = Path(line).name
+        if name.endswith(".json"):
+            filenames.append(name)
+    return sorted(filenames)
+
+
+def load_baseline(against: str, output_dir: str) -> dict[str, dict[str, Any]]:
+    """Load baseline JSON Schema files.
+
+    Args:
+        against: The ``--against`` CLI value — either a git ref
+            (``.git#branch=main``) or a directory path.
+        output_dir: The project's configured output directory (e.g. ``generated/``).
+
+    Returns:
+        Mapping of ``{filename: parsed_json_schema_dict}``.
+
+    Raises:
+        BaselineError: If the baseline cannot be loaded.
+    """
+    if against.startswith(".git#"):
+        return _load_from_git(against, output_dir)
+    return _load_from_directory(against)
+
+
+def _load_from_git(against: str, output_dir: str) -> dict[str, dict[str, Any]]:
+    """Load baseline schemas from a git ref.
+
+    Discovers files from both the baseline ref and the current working tree
+    so that deleted files (present at baseline but absent locally) are still
+    included in the comparison.
+    """
+    ref = _parse_git_ref(against)
+    jsonschema_dir = Path(output_dir) / "jsonschema"
+
+    # Union of current and baseline files — ensures deletions are detected.
+    current_files = set(_discover_current_json_files(jsonschema_dir))
+    baseline_files = set(_discover_baseline_json_files(ref, jsonschema_dir))
+    filenames = sorted(current_files | baseline_files)
+
+    if not filenames:
+        raise BaselineError(
+            f"No JSON Schema files found in {jsonschema_dir} (current or baseline). "
+            "Ensure 'jsonschema' is in your targets and run 'schema-gen generate' first."
+        )
+
+    schemas: dict[str, dict[str, Any]] = {}
+    for filename in filenames:
+        rel_path = str(jsonschema_dir / filename)
+        content = _git_show(ref, rel_path)
+        if content is not None:
+            try:
+                schemas[filename] = json.loads(content)
+            except json.JSONDecodeError as exc:
+                raise BaselineError(
+                    f"Invalid JSON in baseline {ref}:{rel_path}: {exc}"
+                ) from exc
+    return schemas
+
+
+def _load_from_directory(dir_path: str) -> dict[str, dict[str, Any]]:
+    """Load baseline schemas from a directory snapshot."""
+    directory = Path(dir_path)
+    if not directory.is_dir():
+        raise BaselineError(f"Baseline directory not found: {dir_path}")
+
+    schemas: dict[str, dict[str, Any]] = {}
+    for json_file in sorted(directory.glob("*.json")):
+        try:
+            schemas[json_file.name] = json.loads(json_file.read_text())
+        except json.JSONDecodeError as exc:
+            raise BaselineError(f"Invalid JSON in {json_file}: {exc}") from exc
+    return schemas
+
+
+def load_current(output_dir: str) -> dict[str, dict[str, Any]]:
+    """Load current JSON Schema files from the output directory.
+
+    Args:
+        output_dir: The project's configured output directory.
+
+    Returns:
+        Mapping of ``{filename: parsed_json_schema_dict}``.
+
+    Raises:
+        BaselineError: If no JSON Schema files are found.
+    """
+    jsonschema_dir = Path(output_dir) / "jsonschema"
+    if not jsonschema_dir.is_dir():
+        raise BaselineError(
+            f"No jsonschema directory found at {jsonschema_dir}. "
+            "Ensure 'jsonschema' is in your targets and run 'schema-gen generate' first."
+        )
+
+    schemas: dict[str, dict[str, Any]] = {}
+    for json_file in sorted(jsonschema_dir.glob("*.json")):
+        try:
+            schemas[json_file.name] = json.loads(json_file.read_text())
+        except json.JSONDecodeError as exc:
+            raise BaselineError(f"Invalid JSON in {json_file}: {exc}") from exc
+
+    if not schemas:
+        raise BaselineError(
+            f"No JSON Schema files found in {jsonschema_dir}. "
+            "Run 'schema-gen generate' first."
+        )
+
+    return schemas

--- a/src/schema_gen/diff/baseline.py
+++ b/src/schema_gen/diff/baseline.py
@@ -64,21 +64,47 @@ def _discover_current_json_files(jsonschema_dir: Path) -> list[str]:
     return sorted(p.name for p in jsonschema_dir.glob("*.json"))
 
 
+def _repo_relative_posix(path: Path) -> str:
+    """Return *path* as a POSIX-style repo-relative string.
+
+    Uses ``git rev-parse --show-toplevel`` to compute the repo root, then
+    makes *path* relative to it.  Falls back to ``path.as_posix()`` if the
+    repo root cannot be determined (e.g. not inside a git repository).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        repo_root = Path(result.stdout.strip())
+        return path.resolve().relative_to(repo_root).as_posix()
+    except (subprocess.CalledProcessError, ValueError):
+        return path.as_posix()
+
+
 def _discover_baseline_json_files(ref: str, jsonschema_dir: Path) -> list[str]:
     """Return sorted list of ``*.json`` filenames that exist at *ref* in git.
 
     Uses ``git ls-tree`` to enumerate files at the baseline ref, catching
     deletions that ``_discover_current_json_files`` would miss.
+
+    Raises :class:`BaselineError` for unexpected git failures (bad ref, not
+    a git repo, etc.).
     """
-    try:
-        result = subprocess.run(
-            ["git", "ls-tree", "--name-only", ref, str(jsonschema_dir) + "/"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except subprocess.CalledProcessError:
-        return []
+    posix_dir = _repo_relative_posix(jsonschema_dir)
+    result = subprocess.run(
+        ["git", "ls-tree", "--name-only", ref, posix_dir + "/"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        # "not a tree object" / path simply didn't exist at that ref → empty.
+        if "not a tree object" in stderr or not stderr:
+            return []
+        raise BaselineError(f"git ls-tree failed for ref '{ref}': {stderr}")
 
     filenames: list[str] = []
     for line in result.stdout.strip().splitlines():
@@ -130,7 +156,7 @@ def _load_from_git(against: str, output_dir: str) -> dict[str, dict[str, Any]]:
 
     schemas: dict[str, dict[str, Any]] = {}
     for filename in filenames:
-        rel_path = str(jsonschema_dir / filename)
+        rel_path = _repo_relative_posix(jsonschema_dir / filename)
         content = _git_show(ref, rel_path)
         if content is not None:
             try:

--- a/src/schema_gen/diff/comparator.py
+++ b/src/schema_gen/diff/comparator.py
@@ -239,6 +239,23 @@ def _check_enums(
     old_enum = old_def.get("enum")
     new_enum = new_def.get("enum")
 
+    # Enum removed entirely (constrained → unconstrained) — all values deleted.
+    if old_enum is not None and new_enum is None:
+        if _should_check(RuleId.ENUM_VALUE_NO_DELETE, level, ignore_set):
+            for val in sorted(old_enum, key=str):
+                violations.append(
+                    Violation(
+                        rule_id=RuleId.ENUM_VALUE_NO_DELETE,
+                        schema_name=type_name,
+                        field_name=None,
+                        message=(
+                            f"Enum value '{val}' was removed from '{type_name}' "
+                            "(enum constraint removed entirely)"
+                        ),
+                        level=RULE_LEVELS[RuleId.ENUM_VALUE_NO_DELETE],
+                    )
+                )
+
     if old_enum is not None and new_enum is not None:
         # ENUM_VALUE_NO_DELETE
         if _should_check(RuleId.ENUM_VALUE_NO_DELETE, level, ignore_set):
@@ -280,6 +297,22 @@ def _check_enums(
             continue
         old_field_enum = old_props[field_name].get("enum")
         new_field_enum = new_props[field_name].get("enum")
+        if old_field_enum is not None and new_field_enum is None:
+            if _should_check(RuleId.ENUM_VALUE_NO_DELETE, level, ignore_set):
+                for val in sorted(old_field_enum, key=str):
+                    violations.append(
+                        Violation(
+                            rule_id=RuleId.ENUM_VALUE_NO_DELETE,
+                            schema_name=type_name,
+                            field_name=field_name,
+                            message=(
+                                f"Enum value '{val}' was removed from "
+                                f"field '{field_name}' in '{type_name}' "
+                                "(enum constraint removed entirely)"
+                            ),
+                            level=RULE_LEVELS[RuleId.ENUM_VALUE_NO_DELETE],
+                        )
+                    )
         if old_field_enum is not None and new_field_enum is not None:
             if _should_check(RuleId.ENUM_VALUE_NO_DELETE, level, ignore_set):
                 removed = set(old_field_enum) - set(new_field_enum)
@@ -322,8 +355,11 @@ def _check_field_renames(
 ) -> None:
     """Detect potential field renames (WIRE_JSON level).
 
-    Heuristic: if a field was removed and a new field was added with the
-    same type, it's likely a rename.
+    Heuristic: for each effective type, if there is exactly one removed
+    field and exactly one added field with that type, it's likely a rename.
+    When there are multiple removed/added fields of the same type (e.g.
+    two ``string`` fields), the match is ambiguous and we skip it to avoid
+    false positives.
     """
     removed = {k: v for k, v in old_props.items() if k not in new_props}
     added = {k: v for k, v in new_props.items() if k not in old_props}
@@ -331,27 +367,33 @@ def _check_field_renames(
     if not removed or not added:
         return
 
-    matched_removed: set[str] = set()
-    for added_name, added_field in added.items():
-        added_type = _effective_type(added_field)
-        for removed_name, removed_field in removed.items():
-            if removed_name in matched_removed:
-                continue
-            if _effective_type(removed_field) == added_type:
-                violations.append(
-                    Violation(
-                        rule_id=RuleId.FIELD_SAME_NAME,
-                        schema_name=type_name,
-                        field_name=removed_name,
-                        message=(
-                            f"Field '{removed_name}' in '{type_name}' appears to have "
-                            f"been renamed to '{added_name}' (same type: {added_type})"
-                        ),
-                        level=RULE_LEVELS[RuleId.FIELD_SAME_NAME],
-                    )
+    # Group removed and added fields by effective type.
+    removed_by_type: dict[str, list[str]] = {}
+    for name, field in removed.items():
+        t = _effective_type(field)
+        removed_by_type.setdefault(t, []).append(name)
+
+    added_by_type: dict[str, list[str]] = {}
+    for name, field in added.items():
+        t = _effective_type(field)
+        added_by_type.setdefault(t, []).append(name)
+
+    # Only flag renames when there is an unambiguous 1:1 match.
+    for etype, removed_names in removed_by_type.items():
+        added_names = added_by_type.get(etype, [])
+        if len(removed_names) == 1 and len(added_names) == 1:
+            violations.append(
+                Violation(
+                    rule_id=RuleId.FIELD_SAME_NAME,
+                    schema_name=type_name,
+                    field_name=removed_names[0],
+                    message=(
+                        f"Field '{removed_names[0]}' in '{type_name}' may have been "
+                        f"renamed to '{added_names[0]}' (same type: {etype})"
+                    ),
+                    level=RULE_LEVELS[RuleId.FIELD_SAME_NAME],
                 )
-                matched_removed.add(removed_name)
-                break
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -362,9 +404,16 @@ def _check_field_renames(
 def _effective_type(field_schema: dict[str, Any]) -> str:
     """Return the effective JSON Schema type string for a field.
 
-    Handles ``$ref``, ``anyOf``, plain ``type`` (string), and
-    multi-type arrays (e.g. ``["string", "null"]``).  Arrays are sorted
-    so that ordering differences don't cause false positives.
+    Handles ``$ref``, ``anyOf``, plain ``type`` (string), multi-type
+    arrays (e.g. ``["string", "null"]``), and ``array`` with ``items``.
+
+    .. note::
+        Inline nested objects (``{"type": "object", "properties": {...}}``)
+        are represented as ``"object"`` without recursing into their
+        properties.  schema-gen's own output always uses ``$ref`` +
+        ``$defs`` for nested types, so this is not a practical limitation
+        for generated schemas.  If a future generator emits inline nested
+        objects, this function should be extended to recurse.
     """
     if "$ref" in field_schema:
         return f"$ref:{field_schema['$ref']}"
@@ -374,7 +423,12 @@ def _effective_type(field_schema: dict[str, Any]) -> str:
     raw = field_schema.get("type", "any")
     if isinstance(raw, list):
         return ",".join(sorted(raw))
-    return str(raw)
+    type_str = str(raw)
+    # Include element type for arrays so that array<string> != array<integer>.
+    if type_str == "array" and "items" in field_schema:
+        item_type = _effective_type(field_schema["items"])
+        return f"array({item_type})"
+    return type_str
 
 
 def _is_type_width_change(old_type: str, new_type: str) -> bool:

--- a/src/schema_gen/diff/comparator.py
+++ b/src/schema_gen/diff/comparator.py
@@ -1,0 +1,402 @@
+"""JSON Schema comparison engine for breaking change detection."""
+
+from typing import Any
+
+from .rules import (
+    RULE_LEVELS,
+    RuleId,
+    StrictnessLevel,
+    Violation,
+    level_includes,
+)
+
+# Type widening is safe (e.g. integer -> number), narrowing is breaking.
+# Maps JSON Schema type string to a numeric "width" — higher = wider.
+_TYPE_WIDTH: dict[str, int] = {
+    "integer": 1,
+    "number": 2,  # number ⊃ integer
+}
+
+
+def compare_schemas(
+    old: dict[str, dict[str, Any]],
+    new: dict[str, dict[str, Any]],
+    level: StrictnessLevel = StrictnessLevel.WIRE_JSON,
+    ignore: list[str] | None = None,
+) -> list[Violation]:
+    """Compare two sets of JSON Schema files and return breaking change violations.
+
+    Args:
+        old: Baseline schemas ``{filename: parsed_json_dict}``.
+        new: Current schemas ``{filename: parsed_json_dict}``.
+        level: Strictness level controlling which rules are active.
+        ignore: Rule IDs (strings) to suppress.
+
+    Returns:
+        List of :class:`Violation` instances, sorted by schema name.
+    """
+    ignore_set = set(ignore or [])
+    violations: list[Violation] = []
+
+    for filename, old_schema in old.items():
+        new_schema = new.get(filename)
+        if new_schema is None:
+            # Entire file removed — each $defs type is a TYPE_NO_DELETE.
+            violations.extend(
+                _violations_for_deleted_file(old_schema, filename, level, ignore_set)
+            )
+            continue
+
+        violations.extend(
+            _compare_schema_file(old_schema, new_schema, level, ignore_set)
+        )
+
+    violations.sort(key=lambda v: (v.schema_name, v.field_name or ""))
+    return violations
+
+
+def _violations_for_deleted_file(
+    old_schema: dict[str, Any],
+    filename: str,
+    level: StrictnessLevel,
+    ignore_set: set[str],
+) -> list[Violation]:
+    """Generate TYPE_NO_DELETE violations for every type in a removed file."""
+    violations: list[Violation] = []
+    rule = RuleId.TYPE_NO_DELETE
+    if not _should_check(rule, level, ignore_set):
+        return violations
+
+    defs = old_schema.get("$defs", {})
+    for type_name in defs:
+        violations.append(
+            Violation(
+                rule_id=rule,
+                schema_name=type_name,
+                field_name=None,
+                message=f"Schema '{type_name}' was deleted (file {filename} removed)",
+                level=RULE_LEVELS[rule],
+            )
+        )
+    return violations
+
+
+def _compare_schema_file(
+    old: dict[str, Any],
+    new: dict[str, Any],
+    level: StrictnessLevel,
+    ignore_set: set[str],
+) -> list[Violation]:
+    """Compare two JSON Schema file dicts and return violations."""
+    violations: list[Violation] = []
+    old_defs = old.get("$defs", {})
+    new_defs = new.get("$defs", {})
+
+    # Check for deleted types.
+    if _should_check(RuleId.TYPE_NO_DELETE, level, ignore_set):
+        for type_name in old_defs:
+            if type_name not in new_defs:
+                violations.append(
+                    Violation(
+                        rule_id=RuleId.TYPE_NO_DELETE,
+                        schema_name=type_name,
+                        field_name=None,
+                        message=f"Schema '{type_name}' was deleted",
+                        level=RULE_LEVELS[RuleId.TYPE_NO_DELETE],
+                    )
+                )
+
+    # Compare shared types.
+    for type_name in old_defs:
+        if type_name not in new_defs:
+            continue
+        old_def = old_defs[type_name]
+        new_def = new_defs[type_name]
+        violations.extend(
+            _compare_type_def(type_name, old_def, new_def, level, ignore_set)
+        )
+
+    return violations
+
+
+def _compare_type_def(
+    type_name: str,
+    old_def: dict[str, Any],
+    new_def: dict[str, Any],
+    level: StrictnessLevel,
+    ignore_set: set[str],
+) -> list[Violation]:
+    """Compare two ``$defs`` type definitions."""
+    violations: list[Violation] = []
+
+    old_props = old_def.get("properties", {})
+    new_props = new_def.get("properties", {})
+    old_required = set(old_def.get("required", []))
+    new_required = set(new_def.get("required", []))
+
+    # --- FIELD_NO_DELETE ---
+    if _should_check(RuleId.FIELD_NO_DELETE, level, ignore_set):
+        for field_name in old_props:
+            if field_name not in new_props:
+                violations.append(
+                    Violation(
+                        rule_id=RuleId.FIELD_NO_DELETE,
+                        schema_name=type_name,
+                        field_name=field_name,
+                        message=f"Field '{field_name}' was deleted from '{type_name}'",
+                        level=RULE_LEVELS[RuleId.FIELD_NO_DELETE],
+                    )
+                )
+
+    # --- Per-field checks on shared fields ---
+    for field_name in old_props:
+        if field_name not in new_props:
+            continue
+        old_field = old_props[field_name]
+        new_field = new_props[field_name]
+
+        # FIELD_SAME_TYPE — skip width changes (integer↔number) which are
+        # handled exclusively by FIELD_TYPE_NARROWED. Widening is safe and
+        # produces no violation; narrowing is flagged by FIELD_TYPE_NARROWED.
+        if _should_check(RuleId.FIELD_SAME_TYPE, level, ignore_set):
+            old_type = _effective_type(old_field)
+            new_type = _effective_type(new_field)
+            if old_type != new_type:
+                if not _is_type_width_change(old_type, new_type):
+                    violations.append(
+                        Violation(
+                            rule_id=RuleId.FIELD_SAME_TYPE,
+                            schema_name=type_name,
+                            field_name=field_name,
+                            message=(
+                                f"Field '{field_name}' in '{type_name}' changed type "
+                                f"from '{old_type}' to '{new_type}'"
+                            ),
+                            level=RULE_LEVELS[RuleId.FIELD_SAME_TYPE],
+                        )
+                    )
+
+        # FIELD_TYPE_NARROWED
+        if _should_check(RuleId.FIELD_TYPE_NARROWED, level, ignore_set):
+            old_type = _effective_type(old_field)
+            new_type = _effective_type(new_field)
+            if _is_narrowing(old_type, new_type):
+                violations.append(
+                    Violation(
+                        rule_id=RuleId.FIELD_TYPE_NARROWED,
+                        schema_name=type_name,
+                        field_name=field_name,
+                        message=(
+                            f"Field '{field_name}' in '{type_name}' was narrowed "
+                            f"from '{old_type}' to '{new_type}'"
+                        ),
+                        level=RULE_LEVELS[RuleId.FIELD_TYPE_NARROWED],
+                    )
+                )
+
+    # --- FIELD_REQUIRED_ADDED ---
+    if _should_check(RuleId.FIELD_REQUIRED_ADDED, level, ignore_set):
+        added_required = new_required - old_required
+        # Flags any field that is now required but wasn't before — both
+        # brand-new required fields and existing optional fields promoted
+        # to required. Both are breaking for consumers that don't send them.
+        for field_name in sorted(added_required):
+            violations.append(
+                Violation(
+                    rule_id=RuleId.FIELD_REQUIRED_ADDED,
+                    schema_name=type_name,
+                    field_name=field_name,
+                    message=(
+                        f"New required field '{field_name}' added to '{type_name}'"
+                    ),
+                    level=RULE_LEVELS[RuleId.FIELD_REQUIRED_ADDED],
+                )
+            )
+
+    # --- Enum checks ---
+    _check_enums(type_name, old_def, new_def, level, ignore_set, violations)
+
+    # --- WIRE_JSON checks ---
+    if _should_check(RuleId.FIELD_SAME_NAME, level, ignore_set):
+        _check_field_renames(type_name, old_props, new_props, violations)
+
+    return violations
+
+
+def _check_enums(
+    type_name: str,
+    old_def: dict[str, Any],
+    new_def: dict[str, Any],
+    level: StrictnessLevel,
+    ignore_set: set[str],
+    violations: list[Violation],
+) -> None:
+    """Check enum-related rules on a type definition.
+
+    Handles both inline enums (``{"enum": [...]}`` on a property) and
+    top-level enum definitions in ``$defs``.
+    """
+    old_enum = old_def.get("enum")
+    new_enum = new_def.get("enum")
+
+    if old_enum is not None and new_enum is not None:
+        # ENUM_VALUE_NO_DELETE
+        if _should_check(RuleId.ENUM_VALUE_NO_DELETE, level, ignore_set):
+            removed = set(old_enum) - set(new_enum)
+            for val in sorted(removed, key=str):
+                violations.append(
+                    Violation(
+                        rule_id=RuleId.ENUM_VALUE_NO_DELETE,
+                        schema_name=type_name,
+                        field_name=None,
+                        message=(f"Enum value '{val}' was removed from '{type_name}'"),
+                        level=RULE_LEVELS[RuleId.ENUM_VALUE_NO_DELETE],
+                    )
+                )
+
+        # ENUM_VALUE_SAME_NAME — detect value changes at same positions.
+        if _should_check(RuleId.ENUM_VALUE_SAME_NAME, level, ignore_set):
+            for i, old_val in enumerate(old_enum):
+                if i < len(new_enum) and old_val != new_enum[i]:
+                    # A value at the same position changed.
+                    violations.append(
+                        Violation(
+                            rule_id=RuleId.ENUM_VALUE_SAME_NAME,
+                            schema_name=type_name,
+                            field_name=None,
+                            message=(
+                                f"Enum value at position {i} in '{type_name}' "
+                                f"changed from '{old_val}' to '{new_enum[i]}'"
+                            ),
+                            level=RULE_LEVELS[RuleId.ENUM_VALUE_SAME_NAME],
+                        )
+                    )
+
+    # Also check inline enums on properties.
+    old_props = old_def.get("properties", {})
+    new_props = new_def.get("properties", {})
+    for field_name in old_props:
+        if field_name not in new_props:
+            continue
+        old_field_enum = old_props[field_name].get("enum")
+        new_field_enum = new_props[field_name].get("enum")
+        if old_field_enum is not None and new_field_enum is not None:
+            if _should_check(RuleId.ENUM_VALUE_NO_DELETE, level, ignore_set):
+                removed = set(old_field_enum) - set(new_field_enum)
+                for val in sorted(removed, key=str):
+                    violations.append(
+                        Violation(
+                            rule_id=RuleId.ENUM_VALUE_NO_DELETE,
+                            schema_name=type_name,
+                            field_name=field_name,
+                            message=(
+                                f"Enum value '{val}' was removed from "
+                                f"field '{field_name}' in '{type_name}'"
+                            ),
+                            level=RULE_LEVELS[RuleId.ENUM_VALUE_NO_DELETE],
+                        )
+                    )
+            if _should_check(RuleId.ENUM_VALUE_SAME_NAME, level, ignore_set):
+                for i, old_val in enumerate(old_field_enum):
+                    if i < len(new_field_enum) and old_val != new_field_enum[i]:
+                        violations.append(
+                            Violation(
+                                rule_id=RuleId.ENUM_VALUE_SAME_NAME,
+                                schema_name=type_name,
+                                field_name=field_name,
+                                message=(
+                                    f"Enum value at position {i} in field "
+                                    f"'{field_name}' of '{type_name}' changed "
+                                    f"from '{old_val}' to '{new_field_enum[i]}'"
+                                ),
+                                level=RULE_LEVELS[RuleId.ENUM_VALUE_SAME_NAME],
+                            )
+                        )
+
+
+def _check_field_renames(
+    type_name: str,
+    old_props: dict[str, Any],
+    new_props: dict[str, Any],
+    violations: list[Violation],
+) -> None:
+    """Detect potential field renames (WIRE_JSON level).
+
+    Heuristic: if a field was removed and a new field was added with the
+    same type, it's likely a rename.
+    """
+    removed = {k: v for k, v in old_props.items() if k not in new_props}
+    added = {k: v for k, v in new_props.items() if k not in old_props}
+
+    if not removed or not added:
+        return
+
+    matched_removed: set[str] = set()
+    for added_name, added_field in added.items():
+        added_type = _effective_type(added_field)
+        for removed_name, removed_field in removed.items():
+            if removed_name in matched_removed:
+                continue
+            if _effective_type(removed_field) == added_type:
+                violations.append(
+                    Violation(
+                        rule_id=RuleId.FIELD_SAME_NAME,
+                        schema_name=type_name,
+                        field_name=removed_name,
+                        message=(
+                            f"Field '{removed_name}' in '{type_name}' appears to have "
+                            f"been renamed to '{added_name}' (same type: {added_type})"
+                        ),
+                        level=RULE_LEVELS[RuleId.FIELD_SAME_NAME],
+                    )
+                )
+                matched_removed.add(removed_name)
+                break
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _effective_type(field_schema: dict[str, Any]) -> str:
+    """Return the effective JSON Schema type string for a field.
+
+    Handles ``$ref``, ``anyOf``, plain ``type`` (string), and
+    multi-type arrays (e.g. ``["string", "null"]``).  Arrays are sorted
+    so that ordering differences don't cause false positives.
+    """
+    if "$ref" in field_schema:
+        return f"$ref:{field_schema['$ref']}"
+    if "anyOf" in field_schema:
+        parts = sorted(_effective_type(s) for s in field_schema["anyOf"])
+        return f"anyOf({','.join(parts)})"
+    raw = field_schema.get("type", "any")
+    if isinstance(raw, list):
+        return ",".join(sorted(raw))
+    return str(raw)
+
+
+def _is_type_width_change(old_type: str, new_type: str) -> bool:
+    """Return True if *old_type* → *new_type* is a width change (narrowing or widening)."""
+    return old_type in _TYPE_WIDTH and new_type in _TYPE_WIDTH
+
+
+def _is_narrowing(old_type: str, new_type: str) -> bool:
+    """Return True if *old_type* → *new_type* is a type narrowing (breaking)."""
+    old_w = _TYPE_WIDTH.get(old_type)
+    new_w = _TYPE_WIDTH.get(new_type)
+    if old_w is not None and new_w is not None:
+        return new_w < old_w
+    return False
+
+
+def _should_check(
+    rule: RuleId,
+    level: StrictnessLevel,
+    ignore_set: set[str],
+) -> bool:
+    """Return True if *rule* should be checked given *level* and *ignore_set*."""
+    if rule.value in ignore_set:
+        return False
+    return level_includes(level, RULE_LEVELS[rule])

--- a/src/schema_gen/diff/formatter.py
+++ b/src/schema_gen/diff/formatter.py
@@ -14,7 +14,7 @@ def format_text(violations: list[Violation]) -> str:
         return ""
 
     lines: list[str] = []
-    lines.append(f"Found {len(violations)} breaking change(s):\n")
+    lines.append(f"Found {len(violations)} breaking change(s):")
 
     for v in violations:
         location = v.schema_name

--- a/src/schema_gen/diff/formatter.py
+++ b/src/schema_gen/diff/formatter.py
@@ -1,0 +1,41 @@
+"""Output formatters for breaking change violations."""
+
+import json
+
+from .rules import Violation
+
+
+def format_text(violations: list[Violation]) -> str:
+    """Format violations as human-readable text.
+
+    Returns an empty string when there are no violations.
+    """
+    if not violations:
+        return ""
+
+    lines: list[str] = []
+    lines.append(f"Found {len(violations)} breaking change(s):\n")
+
+    for v in violations:
+        location = v.schema_name
+        if v.field_name:
+            location = f"{v.schema_name}.{v.field_name}"
+        lines.append(f"  {v.rule_id.value:30s} {location}")
+        lines.append(f"    {v.message}")
+
+    return "\n".join(lines)
+
+
+def format_json(violations: list[Violation]) -> str:
+    """Format violations as a JSON array."""
+    items = [
+        {
+            "rule": v.rule_id.value,
+            "level": v.level.value,
+            "schema": v.schema_name,
+            "field": v.field_name,
+            "message": v.message,
+        }
+        for v in violations
+    ]
+    return json.dumps(items, indent=2)

--- a/src/schema_gen/diff/rules.py
+++ b/src/schema_gen/diff/rules.py
@@ -1,0 +1,63 @@
+"""Rule definitions and strictness levels for breaking change detection."""
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class StrictnessLevel(Enum):
+    """Strictness levels for breaking change detection.
+
+    Higher levels include all rules from lower levels.
+    """
+
+    WIRE = "WIRE"
+    WIRE_JSON = "WIRE_JSON"
+    SOURCE = "SOURCE"
+
+
+class RuleId(Enum):
+    """Identifiers for individual breaking change rules."""
+
+    # WIRE level — serialization-breaking
+    TYPE_NO_DELETE = "TYPE_NO_DELETE"
+    FIELD_NO_DELETE = "FIELD_NO_DELETE"
+    FIELD_SAME_TYPE = "FIELD_SAME_TYPE"
+    FIELD_TYPE_NARROWED = "FIELD_TYPE_NARROWED"
+    FIELD_REQUIRED_ADDED = "FIELD_REQUIRED_ADDED"
+    ENUM_VALUE_NO_DELETE = "ENUM_VALUE_NO_DELETE"
+
+    # WIRE_JSON level — adds JSON key identity
+    FIELD_SAME_NAME = "FIELD_SAME_NAME"
+    ENUM_VALUE_SAME_NAME = "ENUM_VALUE_SAME_NAME"
+
+
+@dataclass(frozen=True)
+class Violation:
+    """A single breaking change violation."""
+
+    rule_id: RuleId
+    schema_name: str
+    field_name: str | None
+    message: str
+    level: StrictnessLevel
+
+
+# Maps each rule to the minimum strictness level that checks it.
+RULE_LEVELS: dict[RuleId, StrictnessLevel] = {
+    RuleId.TYPE_NO_DELETE: StrictnessLevel.WIRE,
+    RuleId.FIELD_NO_DELETE: StrictnessLevel.WIRE,
+    RuleId.FIELD_SAME_TYPE: StrictnessLevel.WIRE,
+    RuleId.FIELD_TYPE_NARROWED: StrictnessLevel.WIRE,
+    RuleId.FIELD_REQUIRED_ADDED: StrictnessLevel.WIRE,
+    RuleId.ENUM_VALUE_NO_DELETE: StrictnessLevel.WIRE,
+    RuleId.FIELD_SAME_NAME: StrictnessLevel.WIRE_JSON,
+    RuleId.ENUM_VALUE_SAME_NAME: StrictnessLevel.WIRE_JSON,
+}
+
+# Ordered levels for comparison (lower index = less strict).
+_LEVEL_ORDER = [StrictnessLevel.WIRE, StrictnessLevel.WIRE_JSON, StrictnessLevel.SOURCE]
+
+
+def level_includes(active: StrictnessLevel, rule_level: StrictnessLevel) -> bool:
+    """Return True if *active* strictness includes rules at *rule_level*."""
+    return _LEVEL_ORDER.index(active) >= _LEVEL_ORDER.index(rule_level)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,617 @@
+"""Tests for schema-gen diff — breaking change detection."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from schema_gen.cli.main import main
+from schema_gen.diff.comparator import compare_schemas
+from schema_gen.diff.formatter import format_json, format_text
+from schema_gen.diff.rules import RuleId, StrictnessLevel, Violation
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _schema_file(defs: dict, ref: str | None = None) -> dict:
+    """Build a minimal JSON Schema file dict with ``$defs``."""
+    schema: dict = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": defs,
+    }
+    if ref:
+        schema["$ref"] = ref
+    return schema
+
+
+def _type_def(
+    properties: dict | None = None,
+    required: list[str] | None = None,
+    enum: list | None = None,
+) -> dict:
+    """Build a ``$defs`` entry."""
+    d: dict = {"type": "object", "properties": properties or {}}
+    if required:
+        d["required"] = required
+    if enum is not None:
+        d["enum"] = enum
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Rule tests — WIRE level
+# ---------------------------------------------------------------------------
+
+
+class TestTypeNoDelete:
+    def test_deleted_type_in_defs(self):
+        old = {"user.json": _schema_file({"User": _type_def()})}
+        new = {"user.json": _schema_file({})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert len(vs) == 1
+        assert vs[0].rule_id == RuleId.TYPE_NO_DELETE
+        assert vs[0].schema_name == "User"
+
+    def test_deleted_file(self):
+        old = {"user.json": _schema_file({"User": _type_def(), "Admin": _type_def()})}
+        new = {}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert len(vs) == 2
+        assert all(v.rule_id == RuleId.TYPE_NO_DELETE for v in vs)
+
+    def test_new_type_is_safe(self):
+        old = {"user.json": _schema_file({})}
+        new = {"user.json": _schema_file({"User": _type_def()})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert vs == []
+
+
+class TestFieldNoDelete:
+    def test_removed_field(self):
+        old_def = _type_def(
+            properties={"name": {"type": "string"}, "age": {"type": "integer"}}
+        )
+        new_def = _type_def(properties={"name": {"type": "string"}})
+        old = {"u.json": _schema_file({"User": old_def})}
+        new = {"u.json": _schema_file({"User": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert len(vs) == 1
+        assert vs[0].rule_id == RuleId.FIELD_NO_DELETE
+        assert vs[0].field_name == "age"
+
+    def test_added_field_is_safe(self):
+        old_def = _type_def(properties={"name": {"type": "string"}})
+        new_def = _type_def(
+            properties={"name": {"type": "string"}, "age": {"type": "integer"}}
+        )
+        old = {"u.json": _schema_file({"User": old_def})}
+        new = {"u.json": _schema_file({"User": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert vs == []
+
+
+class TestFieldSameType:
+    def test_type_changed(self):
+        old_def = _type_def(properties={"age": {"type": "string"}})
+        new_def = _type_def(properties={"age": {"type": "boolean"}})
+        old = {"u.json": _schema_file({"User": old_def})}
+        new = {"u.json": _schema_file({"User": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert any(v.rule_id == RuleId.FIELD_SAME_TYPE for v in vs)
+
+    def test_same_type_is_safe(self):
+        old_def = _type_def(properties={"age": {"type": "integer"}})
+        new_def = _type_def(properties={"age": {"type": "integer"}})
+        old = {"u.json": _schema_file({"User": old_def})}
+        new = {"u.json": _schema_file({"User": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert vs == []
+
+
+class TestFieldTypeNarrowed:
+    def test_number_to_integer_is_narrowing(self):
+        old_def = _type_def(properties={"val": {"type": "number"}})
+        new_def = _type_def(properties={"val": {"type": "integer"}})
+        old = {"u.json": _schema_file({"T": old_def})}
+        new = {"u.json": _schema_file({"T": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert any(v.rule_id == RuleId.FIELD_TYPE_NARROWED for v in vs)
+        # Should NOT also fire FIELD_SAME_TYPE for width changes.
+        assert not any(v.rule_id == RuleId.FIELD_SAME_TYPE for v in vs)
+
+    def test_integer_to_number_is_widening_safe(self):
+        old_def = _type_def(properties={"val": {"type": "integer"}})
+        new_def = _type_def(properties={"val": {"type": "number"}})
+        old = {"u.json": _schema_file({"T": old_def})}
+        new = {"u.json": _schema_file({"T": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert vs == []
+
+
+class TestFieldRequiredAdded:
+    def test_new_required_field(self):
+        old_def = _type_def(properties={"name": {"type": "string"}}, required=["name"])
+        new_def = _type_def(
+            properties={"name": {"type": "string"}, "email": {"type": "string"}},
+            required=["name", "email"],
+        )
+        old = {"u.json": _schema_file({"User": old_def})}
+        new = {"u.json": _schema_file({"User": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert any(v.rule_id == RuleId.FIELD_REQUIRED_ADDED for v in vs)
+        assert any(v.field_name == "email" for v in vs)
+
+    def test_new_optional_field_is_safe(self):
+        old_def = _type_def(properties={"name": {"type": "string"}}, required=["name"])
+        new_def = _type_def(
+            properties={"name": {"type": "string"}, "bio": {"type": "string"}},
+            required=["name"],
+        )
+        old = {"u.json": _schema_file({"User": old_def})}
+        new = {"u.json": _schema_file({"User": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert vs == []
+
+
+class TestEnumValueNoDelete:
+    def test_removed_enum_variant(self):
+        old_defs = {
+            "Status": {"type": "string", "enum": ["active", "inactive", "banned"]}
+        }
+        new_defs = {"Status": {"type": "string", "enum": ["active", "inactive"]}}
+        old = {"s.json": _schema_file(old_defs)}
+        new = {"s.json": _schema_file(new_defs)}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert len(vs) == 1
+        assert vs[0].rule_id == RuleId.ENUM_VALUE_NO_DELETE
+        assert "banned" in vs[0].message
+
+    def test_added_enum_variant_is_safe(self):
+        old_defs = {"Status": {"type": "string", "enum": ["active", "inactive"]}}
+        new_defs = {
+            "Status": {"type": "string", "enum": ["active", "inactive", "banned"]}
+        }
+        old = {"s.json": _schema_file(old_defs)}
+        new = {"s.json": _schema_file(new_defs)}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert vs == []
+
+    def test_inline_enum_removed(self):
+        old_def = _type_def(
+            properties={"status": {"type": "string", "enum": ["a", "b", "c"]}}
+        )
+        new_def = _type_def(
+            properties={"status": {"type": "string", "enum": ["a", "b"]}}
+        )
+        old = {"u.json": _schema_file({"User": old_def})}
+        new = {"u.json": _schema_file({"User": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert any(v.rule_id == RuleId.ENUM_VALUE_NO_DELETE for v in vs)
+
+
+# ---------------------------------------------------------------------------
+# Rule tests — WIRE_JSON level
+# ---------------------------------------------------------------------------
+
+
+class TestFieldSameName:
+    def test_rename_detected(self):
+        old_def = _type_def(properties={"user_name": {"type": "string"}})
+        new_def = _type_def(properties={"username": {"type": "string"}})
+        old = {"u.json": _schema_file({"User": old_def})}
+        new = {"u.json": _schema_file({"User": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE_JSON)
+        same_name = [v for v in vs if v.rule_id == RuleId.FIELD_SAME_NAME]
+        assert len(same_name) == 1
+        assert "user_name" in same_name[0].message
+        assert "username" in same_name[0].message
+
+    def test_not_flagged_at_wire_level(self):
+        old_def = _type_def(properties={"user_name": {"type": "string"}})
+        new_def = _type_def(properties={"username": {"type": "string"}})
+        old = {"u.json": _schema_file({"User": old_def})}
+        new = {"u.json": _schema_file({"User": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert not any(v.rule_id == RuleId.FIELD_SAME_NAME for v in vs)
+
+
+class TestEnumValueSameName:
+    def test_value_changed_at_position(self):
+        old_defs = {"Status": {"type": "string", "enum": ["active", "inactive"]}}
+        new_defs = {"Status": {"type": "string", "enum": ["enabled", "inactive"]}}
+        old = {"s.json": _schema_file(old_defs)}
+        new = {"s.json": _schema_file(new_defs)}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE_JSON)
+        same_name = [v for v in vs if v.rule_id == RuleId.ENUM_VALUE_SAME_NAME]
+        assert len(same_name) == 1
+        assert "active" in same_name[0].message
+        assert "enabled" in same_name[0].message
+
+    def test_not_flagged_at_wire_level(self):
+        old_defs = {"Status": {"type": "string", "enum": ["active", "inactive"]}}
+        new_defs = {"Status": {"type": "string", "enum": ["enabled", "inactive"]}}
+        old = {"s.json": _schema_file(old_defs)}
+        new = {"s.json": _schema_file(new_defs)}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert not any(v.rule_id == RuleId.ENUM_VALUE_SAME_NAME for v in vs)
+
+
+# ---------------------------------------------------------------------------
+# Ignore flag
+# ---------------------------------------------------------------------------
+
+
+class TestIgnore:
+    def test_ignore_suppresses_rule(self):
+        old = {"u.json": _schema_file({"User": _type_def()})}
+        new = {"u.json": _schema_file({})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE, ignore=["TYPE_NO_DELETE"])
+        assert vs == []
+
+    def test_ignore_only_specified_rule(self):
+        old_def = _type_def(
+            properties={"name": {"type": "string"}, "age": {"type": "integer"}},
+            required=["name"],
+        )
+        new_def = _type_def(
+            properties={"name": {"type": "string"}},
+            required=["name"],
+        )
+        old = {"u.json": _schema_file({"User": old_def})}
+        new = {"u.json": _schema_file({"User": new_def})}
+        vs_all = compare_schemas(old, new, StrictnessLevel.WIRE)
+        vs_ignore = compare_schemas(
+            old, new, StrictnessLevel.WIRE, ignore=["FIELD_NO_DELETE"]
+        )
+        assert len(vs_ignore) < len(vs_all)
+
+
+# ---------------------------------------------------------------------------
+# Safe changes
+# ---------------------------------------------------------------------------
+
+
+class TestRefAndAnyOfTypes:
+    def test_ref_same_is_safe(self):
+        old_def = _type_def(properties={"role": {"$ref": "#/$defs/Role"}})
+        new_def = _type_def(properties={"role": {"$ref": "#/$defs/Role"}})
+        old = {"u.json": _schema_file({"User": old_def})}
+        new = {"u.json": _schema_file({"User": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert vs == []
+
+    def test_ref_changed(self):
+        old_def = _type_def(properties={"role": {"$ref": "#/$defs/Role"}})
+        new_def = _type_def(properties={"role": {"$ref": "#/$defs/Permission"}})
+        old = {"u.json": _schema_file({"User": old_def})}
+        new = {"u.json": _schema_file({"User": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert any(v.rule_id == RuleId.FIELD_SAME_TYPE for v in vs)
+
+    def test_anyof_same_is_safe(self):
+        anyof = {"anyOf": [{"type": "string"}, {"type": "integer"}]}
+        old_def = _type_def(properties={"val": anyof})
+        new_def = _type_def(properties={"val": anyof})
+        old = {"u.json": _schema_file({"T": old_def})}
+        new = {"u.json": _schema_file({"T": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert vs == []
+
+    def test_anyof_reordered_is_safe(self):
+        """Different ordering of anyOf variants should not be a type change."""
+        old_anyof = {"anyOf": [{"type": "string"}, {"type": "integer"}]}
+        new_anyof = {"anyOf": [{"type": "integer"}, {"type": "string"}]}
+        old_def = _type_def(properties={"val": old_anyof})
+        new_def = _type_def(properties={"val": new_anyof})
+        old = {"u.json": _schema_file({"T": old_def})}
+        new = {"u.json": _schema_file({"T": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert vs == []
+
+    def test_anyof_changed(self):
+        old_anyof = {"anyOf": [{"type": "string"}, {"type": "integer"}]}
+        new_anyof = {"anyOf": [{"type": "string"}, {"type": "boolean"}]}
+        old_def = _type_def(properties={"val": old_anyof})
+        new_def = _type_def(properties={"val": new_anyof})
+        old = {"u.json": _schema_file({"T": old_def})}
+        new = {"u.json": _schema_file({"T": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert any(v.rule_id == RuleId.FIELD_SAME_TYPE for v in vs)
+
+    def test_list_type_ordering_is_safe(self):
+        """JSON Schema list types like ["string", "null"] should match regardless of order."""
+        old_def = _type_def(properties={"val": {"type": ["string", "null"]}})
+        new_def = _type_def(properties={"val": {"type": ["null", "string"]}})
+        old = {"u.json": _schema_file({"T": old_def})}
+        new = {"u.json": _schema_file({"T": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert vs == []
+
+
+class TestInlineEnumValueSameName:
+    def test_inline_enum_value_changed(self):
+        old_def = _type_def(
+            properties={"status": {"type": "string", "enum": ["active", "inactive"]}}
+        )
+        new_def = _type_def(
+            properties={"status": {"type": "string", "enum": ["enabled", "inactive"]}}
+        )
+        old = {"u.json": _schema_file({"User": old_def})}
+        new = {"u.json": _schema_file({"User": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE_JSON)
+        same_name = [v for v in vs if v.rule_id == RuleId.ENUM_VALUE_SAME_NAME]
+        assert len(same_name) == 1
+        assert same_name[0].field_name == "status"
+
+
+class TestSafeChanges:
+    def test_new_schema_file_is_safe(self):
+        old: dict = {}
+        new = {"user.json": _schema_file({"User": _type_def()})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE_JSON)
+        assert vs == []
+
+    def test_add_optional_field_with_default_is_safe(self):
+        old_def = _type_def(properties={"name": {"type": "string"}}, required=["name"])
+        new_def = _type_def(
+            properties={
+                "name": {"type": "string"},
+                "bio": {"type": "string", "default": ""},
+            },
+            required=["name"],
+        )
+        old = {"u.json": _schema_file({"User": old_def})}
+        new = {"u.json": _schema_file({"User": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE_JSON)
+        assert vs == []
+
+
+# ---------------------------------------------------------------------------
+# Formatter tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatText:
+    def test_empty(self):
+        assert format_text([]) == ""
+
+    def test_single_violation(self):
+        v = Violation(
+            rule_id=RuleId.FIELD_NO_DELETE,
+            schema_name="User",
+            field_name="age",
+            message="Field 'age' was deleted from 'User'",
+            level=StrictnessLevel.WIRE,
+        )
+        text = format_text([v])
+        assert "1 breaking change" in text
+        assert "FIELD_NO_DELETE" in text
+        assert "User.age" in text
+
+
+class TestFormatJson:
+    def test_empty(self):
+        result = json.loads(format_json([]))
+        assert result == []
+
+    def test_single_violation(self):
+        v = Violation(
+            rule_id=RuleId.FIELD_NO_DELETE,
+            schema_name="User",
+            field_name="age",
+            message="Field 'age' was deleted from 'User'",
+            level=StrictnessLevel.WIRE,
+        )
+        result = json.loads(format_json([v]))
+        assert len(result) == 1
+        assert result[0]["rule"] == "FIELD_NO_DELETE"
+        assert result[0]["schema"] == "User"
+        assert result[0]["field"] == "age"
+
+
+# ---------------------------------------------------------------------------
+# CLI tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiffCLI:
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    def test_diff_help(self):
+        result = self.runner.invoke(main, ["diff", "--help"])
+        assert result.exit_code == 0
+        assert "--against" in result.output
+
+    @patch("schema_gen.cli.main.create_generation_engine")
+    @patch("schema_gen.cli.main.load_current")
+    @patch("schema_gen.cli.main.load_baseline")
+    def test_diff_no_breaking_changes(self, mock_baseline, mock_current, mock_engine):
+        mock_engine.return_value.config.output_dir = "generated/"
+        schema = _schema_file(
+            {"User": _type_def(properties={"name": {"type": "string"}})}
+        )
+        mock_baseline.return_value = {"user.json": schema}
+        mock_current.return_value = {"user.json": schema}
+
+        result = self.runner.invoke(main, ["diff", "--against", ".git#branch=main"])
+        assert result.exit_code == 0
+        assert "No breaking changes" in result.output
+
+    @patch("schema_gen.cli.main.create_generation_engine")
+    @patch("schema_gen.cli.main.load_current")
+    @patch("schema_gen.cli.main.load_baseline")
+    def test_diff_with_breaking_changes(self, mock_baseline, mock_current, mock_engine):
+        mock_engine.return_value.config.output_dir = "generated/"
+        old_schema = _schema_file(
+            {"User": _type_def(properties={"name": {"type": "string"}})}
+        )
+        new_schema = _schema_file({"User": _type_def(properties={})})
+        mock_baseline.return_value = {"user.json": old_schema}
+        mock_current.return_value = {"user.json": new_schema}
+
+        result = self.runner.invoke(main, ["diff", "--against", ".git#branch=main"])
+        assert result.exit_code == 1
+        assert "FIELD_NO_DELETE" in result.output
+
+    @patch("schema_gen.cli.main.create_generation_engine")
+    @patch("schema_gen.cli.main.load_current")
+    @patch("schema_gen.cli.main.load_baseline")
+    def test_diff_json_format(self, mock_baseline, mock_current, mock_engine):
+        mock_engine.return_value.config.output_dir = "generated/"
+        old_schema = _schema_file(
+            {"User": _type_def(properties={"name": {"type": "string"}})}
+        )
+        new_schema = _schema_file({"User": _type_def(properties={})})
+        mock_baseline.return_value = {"user.json": old_schema}
+        mock_current.return_value = {"user.json": new_schema}
+
+        result = self.runner.invoke(
+            main, ["diff", "--against", ".git#branch=main", "--format", "json"]
+        )
+        assert result.exit_code == 1
+        parsed = json.loads(result.output)
+        assert len(parsed) >= 1
+        assert parsed[0]["rule"] == "FIELD_NO_DELETE"
+
+    @patch("schema_gen.cli.main.create_generation_engine")
+    @patch("schema_gen.cli.main.load_current")
+    @patch("schema_gen.cli.main.load_baseline")
+    def test_diff_with_ignore(self, mock_baseline, mock_current, mock_engine):
+        mock_engine.return_value.config.output_dir = "generated/"
+        old_schema = _schema_file(
+            {"User": _type_def(properties={"name": {"type": "string"}})}
+        )
+        new_schema = _schema_file({"User": _type_def(properties={})})
+        mock_baseline.return_value = {"user.json": old_schema}
+        mock_current.return_value = {"user.json": new_schema}
+
+        result = self.runner.invoke(
+            main,
+            ["diff", "--against", ".git#branch=main", "--ignore", "FIELD_NO_DELETE"],
+        )
+        assert result.exit_code == 0
+        assert "No breaking changes" in result.output
+
+    @patch("schema_gen.cli.main.create_generation_engine")
+    @patch("schema_gen.cli.main.load_current")
+    def test_diff_baseline_error(self, mock_current, mock_engine):
+        mock_engine.return_value.config.output_dir = "generated/"
+        mock_current.return_value = {}
+
+        result = self.runner.invoke(main, ["diff", "--against", "/nonexistent/path"])
+        assert result.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# Baseline loader tests
+# ---------------------------------------------------------------------------
+
+
+class TestBaselineLoader:
+    def test_parse_git_branch(self):
+        from schema_gen.diff.baseline import _parse_git_ref
+
+        assert _parse_git_ref(".git#branch=main") == "main"
+
+    def test_parse_git_tag(self):
+        from schema_gen.diff.baseline import _parse_git_ref
+
+        assert _parse_git_ref(".git#tag=v1.0.0") == "v1.0.0"
+
+    def test_parse_git_commit(self):
+        from schema_gen.diff.baseline import _parse_git_ref
+
+        assert _parse_git_ref(".git#commit=abc123") == "abc123"
+
+    def test_parse_invalid_format(self):
+        from schema_gen.diff.baseline import BaselineError, _parse_git_ref
+
+        with pytest.raises(BaselineError):
+            _parse_git_ref(".git#invalid")
+
+    def test_load_from_directory(self, tmp_path):
+        from schema_gen.diff.baseline import _load_from_directory
+
+        schema = _schema_file({"User": _type_def()})
+        (tmp_path / "user.json").write_text(json.dumps(schema))
+
+        result = _load_from_directory(str(tmp_path))
+        assert "user.json" in result
+        assert result["user.json"]["$defs"]["User"]["type"] == "object"
+
+    def test_load_from_nonexistent_directory(self):
+        from schema_gen.diff.baseline import BaselineError, _load_from_directory
+
+        with pytest.raises(BaselineError, match="not found"):
+            _load_from_directory("/nonexistent/path")
+
+    def test_load_current(self, tmp_path):
+        from schema_gen.diff.baseline import load_current
+
+        jsonschema_dir = tmp_path / "jsonschema"
+        jsonschema_dir.mkdir()
+        schema = _schema_file({"User": _type_def()})
+        (jsonschema_dir / "user.json").write_text(json.dumps(schema))
+
+        result = load_current(str(tmp_path))
+        assert "user.json" in result
+
+    def test_load_current_no_dir(self, tmp_path):
+        from schema_gen.diff.baseline import BaselineError, load_current
+
+        with pytest.raises(BaselineError, match="No jsonschema directory"):
+            load_current(str(tmp_path))
+
+    @patch("schema_gen.diff.baseline._git_show")
+    @patch("schema_gen.diff.baseline._discover_baseline_json_files")
+    def test_load_from_git(self, mock_baseline_files, mock_git_show, tmp_path):
+        from schema_gen.diff.baseline import load_baseline
+
+        # Set up current files so _discover_current_json_files works.
+        jsonschema_dir = tmp_path / "jsonschema"
+        jsonschema_dir.mkdir()
+        (jsonschema_dir / "user.json").write_text("{}")
+
+        mock_baseline_files.return_value = ["user.json"]
+        schema = _schema_file({"User": _type_def()})
+        mock_git_show.return_value = json.dumps(schema)
+
+        result = load_baseline(".git#branch=main", str(tmp_path))
+        assert "user.json" in result
+        mock_git_show.assert_called_once()
+
+    @patch("schema_gen.diff.baseline._git_show")
+    @patch("schema_gen.diff.baseline._discover_baseline_json_files")
+    def test_load_from_git_detects_deleted_files(
+        self, mock_baseline_files, mock_git_show, tmp_path
+    ):
+        """Files that exist at the baseline but are deleted locally should still be loaded."""
+        from schema_gen.diff.baseline import load_baseline
+
+        # Only user.json exists locally; order.json was deleted.
+        jsonschema_dir = tmp_path / "jsonschema"
+        jsonschema_dir.mkdir()
+        (jsonschema_dir / "user.json").write_text("{}")
+
+        # Baseline ref has both files.
+        mock_baseline_files.return_value = ["order.json", "user.json"]
+
+        user_schema = _schema_file({"User": _type_def()})
+        order_schema = _schema_file({"Order": _type_def()})
+
+        def git_show_side_effect(ref, path):
+            if "order.json" in path:
+                return json.dumps(order_schema)
+            if "user.json" in path:
+                return json.dumps(user_schema)
+            return None
+
+        mock_git_show.side_effect = git_show_side_effect
+
+        result = load_baseline(".git#branch=main", str(tmp_path))
+        assert "user.json" in result
+        assert "order.json" in result

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -191,6 +191,29 @@ class TestEnumValueNoDelete:
         vs = compare_schemas(old, new, StrictnessLevel.WIRE)
         assert any(v.rule_id == RuleId.ENUM_VALUE_NO_DELETE for v in vs)
 
+    def test_enum_replaced_with_plain_type(self):
+        """Removing enum constraint entirely should flag all values as deleted."""
+        old_defs = {"Status": {"type": "string", "enum": ["active", "inactive"]}}
+        new_defs = {"Status": {"type": "string"}}
+        old = {"s.json": _schema_file(old_defs)}
+        new = {"s.json": _schema_file(new_defs)}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        enum_vs = [v for v in vs if v.rule_id == RuleId.ENUM_VALUE_NO_DELETE]
+        assert len(enum_vs) == 2
+        assert any("active" in v.message for v in enum_vs)
+        assert any("inactive" in v.message for v in enum_vs)
+
+    def test_inline_enum_replaced_with_plain_type(self):
+        old_def = _type_def(
+            properties={"status": {"type": "string", "enum": ["a", "b"]}}
+        )
+        new_def = _type_def(properties={"status": {"type": "string"}})
+        old = {"u.json": _schema_file({"User": old_def})}
+        new = {"u.json": _schema_file({"User": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        enum_vs = [v for v in vs if v.rule_id == RuleId.ENUM_VALUE_NO_DELETE]
+        assert len(enum_vs) == 2
+
 
 # ---------------------------------------------------------------------------
 # Rule tests — WIRE_JSON level
@@ -216,6 +239,26 @@ class TestFieldSameName:
         new = {"u.json": _schema_file({"User": new_def})}
         vs = compare_schemas(old, new, StrictnessLevel.WIRE)
         assert not any(v.rule_id == RuleId.FIELD_SAME_NAME for v in vs)
+
+    def test_ambiguous_rename_not_flagged(self):
+        """Multiple removed+added string fields should not flag a rename."""
+        old_def = _type_def(
+            properties={
+                "email": {"type": "string"},
+                "phone": {"type": "string"},
+            }
+        )
+        new_def = _type_def(
+            properties={
+                "contact_email": {"type": "string"},
+                "mobile": {"type": "string"},
+            }
+        )
+        old = {"u.json": _schema_file({"User": old_def})}
+        new = {"u.json": _schema_file({"User": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE_JSON)
+        same_name = [v for v in vs if v.rule_id == RuleId.FIELD_SAME_NAME]
+        assert same_name == []
 
 
 class TestEnumValueSameName:
@@ -329,6 +372,45 @@ class TestRefAndAnyOfTypes:
         new = {"u.json": _schema_file({"T": new_def})}
         vs = compare_schemas(old, new, StrictnessLevel.WIRE)
         assert vs == []
+
+
+class TestArrayItemsType:
+    def test_array_item_type_change_detected(self):
+        """Changing array<string> to array<integer> should be a type change."""
+        old_def = _type_def(
+            properties={"tags": {"type": "array", "items": {"type": "string"}}}
+        )
+        new_def = _type_def(
+            properties={"tags": {"type": "array", "items": {"type": "integer"}}}
+        )
+        old = {"u.json": _schema_file({"User": old_def})}
+        new = {"u.json": _schema_file({"User": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert any(v.rule_id == RuleId.FIELD_SAME_TYPE for v in vs)
+
+    def test_array_same_item_type_is_safe(self):
+        old_def = _type_def(
+            properties={"tags": {"type": "array", "items": {"type": "string"}}}
+        )
+        new_def = _type_def(
+            properties={"tags": {"type": "array", "items": {"type": "string"}}}
+        )
+        old = {"u.json": _schema_file({"User": old_def})}
+        new = {"u.json": _schema_file({"User": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert vs == []
+
+    def test_array_ref_item_type_change(self):
+        old_def = _type_def(
+            properties={"legs": {"type": "array", "items": {"$ref": "#/$defs/Leg"}}}
+        )
+        new_def = _type_def(
+            properties={"legs": {"type": "array", "items": {"$ref": "#/$defs/Step"}}}
+        )
+        old = {"u.json": _schema_file({"T": old_def})}
+        new = {"u.json": _schema_file({"T": new_def})}
+        vs = compare_schemas(old, new, StrictnessLevel.WIRE)
+        assert any(v.rule_id == RuleId.FIELD_SAME_TYPE for v in vs)
 
 
 class TestInlineEnumValueSameName:
@@ -504,6 +586,15 @@ class TestDiffCLI:
 
         result = self.runner.invoke(main, ["diff", "--against", "/nonexistent/path"])
         assert result.exit_code == 2
+
+    def test_diff_invalid_ignore_rule(self):
+        """Typo in --ignore should error with exit code 2."""
+        result = self.runner.invoke(
+            main,
+            ["diff", "--against", ".git#branch=main", "--ignore", "FIELD_NO_DELET"],
+        )
+        assert result.exit_code == 2
+        assert "Unknown rule" in result.output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements Phase 1 of #23: `schema-gen diff` CLI command for detecting breaking changes in JSON Schema output.

- Pure Python JSON Schema dict comparison engine (~400 LOC) — no external binary dependencies
- 8 breaking change rules across WIRE and WIRE_JSON strictness levels
- Git baseline loading via `git show` (branches, tags, commits) and directory snapshot baselines
- `--format text` (human-readable) and `--format json` (CI-parseable) output
- `--ignore` flag to suppress specific rules for intentional breaking changes
- Exit codes: 0 (clean), 1 (breaking), 2 (tool error)
- Detects deleted schema files from baseline via `git ls-tree` (not just current working tree)
- Handles `$ref`, `anyOf`, list-typed nullable fields, and inline enum comparisons

### Rules implemented

| Rule | Level | Description |
|------|-------|-------------|
| `TYPE_NO_DELETE` | WIRE | Schema type removed |
| `FIELD_NO_DELETE` | WIRE | Field removed |
| `FIELD_SAME_TYPE` | WIRE | Field type changed incompatibly |
| `FIELD_TYPE_NARROWED` | WIRE | Numeric type narrowed (number→integer) |
| `FIELD_REQUIRED_ADDED` | WIRE | New required field added |
| `ENUM_VALUE_NO_DELETE` | WIRE | Enum variant removed |
| `FIELD_SAME_NAME` | WIRE_JSON | Field renamed (heuristic) |
| `ENUM_VALUE_SAME_NAME` | WIRE_JSON | Enum value changed at position |

## Test plan

- [x] 49 tests covering all 8 rules, safe changes, `$ref`/`anyOf`/list types, inline enums, formatters, CLI commands, baseline loading, and deleted-file detection
- [x] Full existing test suite passes (4 pre-existing failures unrelated to this change)
- [x] All pre-commit hooks pass (ruff check, ruff format, etc.)
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)