### PR TITLE
docs: surface schema-gen diff in README and getting-started

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Generated files are committed to your repository, ensuring:
 - **CLI Tools** - Complete command-line interface
 - **File Watching** - Auto-regeneration during development
 - **Pre-commit Hooks** - Automatic generation in git workflow
+- **Breaking Change Detection** - `schema-gen diff` detects breaking schema changes before merge (inspired by [buf](https://buf.build/docs/breaking/rules/))
 
 ## 🛠️ CLI Commands
 
@@ -322,6 +323,22 @@ Validate that generated files are up-to-date with schema definitions.
 ```bash
 schema-gen validate
 ```
+
+### `schema-gen diff`
+Detect breaking changes by comparing schemas against a baseline.
+
+```bash
+# Compare against main branch
+schema-gen diff --against .git#branch=main
+
+# JSON output for CI
+schema-gen diff --against .git#branch=main --format json
+
+# Suppress a known intentional break
+schema-gen diff --against .git#branch=main --ignore FIELD_NO_DELETE
+```
+
+Detects: deleted types/fields, type changes, type narrowing, new required fields, removed enum variants, field renames, and enum value changes. See [CLI Reference](docs/cli-reference.md) for the full rule taxonomy.
 
 ### `schema-gen install-hooks`
 Set up pre-commit hooks for automatic generation.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -185,6 +185,22 @@ schema-gen install-hooks
 
 This ensures generated files stay in sync with schema changes.
 
+### Breaking Change Detection
+Catch breaking schema changes before they reach production:
+
+```bash
+schema-gen diff --against .git#branch=main
+```
+
+This compares your current JSON Schema output against a baseline and reports breaking changes (deleted fields, type changes, removed enum values, etc.). Add it to your CI pipeline to gate PRs:
+
+```yaml
+- name: Schema breaking change detection
+  run: schema-gen diff --against .git#branch=main --format json
+```
+
+Requires `jsonschema` in your configured targets. See [CLI Reference](cli-reference.md#schema-gen-diff) for all options and rules.
+
 ## Next Steps
 
 - **[Schema Format Reference](schema-format.md)** - Complete field types and constraints

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,7 @@ Schema Gen provides a **single source of truth** approach:
 - **File Watching** - Auto-regeneration during development
 - **Pre-commit Hooks** - Automatic generation in git workflow
 - **Type Safety** - Full IDE support and static type checking
+- **Breaking Change Detection** - Detect breaking schema changes before merge with `schema-gen diff`
 
 ### Planned Features
 - **SQLAlchemy Generation** - Database models and migrations


### PR DESCRIPTION
## Summary

- Add breaking change detection to README features list and CLI commands section
- Add feature mention in docs homepage (`docs/index.md`)
- Add CI workflow example in getting-started guide (`docs/getting-started.md`)

Follow-up to #24 which added the `schema-gen diff` command but only documented it in `cli-reference.md`.

## Test plan

- [x] Pre-commit hooks pass (markdown dead link check included)
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)