### PR TITLE
fix: preserve str/int mixin on enums in Pydantic generator (#26)

### DIFF
--- a/src/schema_gen/core/usr.py
+++ b/src/schema_gen/core/usr.py
@@ -75,6 +75,13 @@ class USREnum:
     name: str
     values: list[tuple[str, Any]]  # (member_name, member_value)
 
+    # Mixin base type for the enum (e.g. ``str``, ``int``).  When the
+    # source enum inherits from ``str, Enum`` or ``int, Enum`` (or
+    # ``StrEnum`` / ``IntEnum``) generators must preserve that mixin so
+    # that JSON serialization round-trips correctly.  ``None`` means a
+    # plain ``Enum`` with no mixin.
+    value_type: type | None = None
+
     # Per-target custom code (raw_code, imports, methods, derives, ...)
     # extracted from PydanticMeta / SerdeMeta inner classes on the Enum.
     custom_code: dict[str, dict] = field(default_factory=dict)

--- a/src/schema_gen/generators/pydantic_generator.py
+++ b/src/schema_gen/generators/pydantic_generator.py
@@ -582,7 +582,13 @@ class PydanticGenerator(BaseGenerator):
         # Generate enum classes before models
         for enum_def in enums:
             lines.append("")
-            lines.append(f"class {enum_def.name}(Enum):")
+            # Preserve the mixin base type (str, int) when the source enum
+            # inherits from it — e.g. ``class Foo(str, Enum):``.
+            if enum_def.value_type is not None:
+                mixin_name = enum_def.value_type.__name__
+                lines.append(f"class {enum_def.name}({mixin_name}, Enum):")
+            else:
+                lines.append(f"class {enum_def.name}(Enum):")
             for member_name, member_value in enum_def.values:
                 if isinstance(member_value, str):
                     lines.append(f'    {member_name} = "{member_value}"')

--- a/src/schema_gen/parsers/schema_parser.py
+++ b/src/schema_gen/parsers/schema_parser.py
@@ -17,6 +17,33 @@ _ENUM_META_CLASSES = {
 }
 
 
+def _detect_enum_value_type(enum_cls: type) -> type | None:
+    """Return the mixin base type (``str``, ``int``, …) of an Enum class.
+
+    Detects both explicit mixin forms (``class Foo(str, Enum)``) and
+    stdlib convenience classes (``StrEnum``, ``IntEnum``).  Returns
+    ``None`` for a plain ``Enum`` with no mixin.
+    """
+    import enum as _enum_mod
+
+    # StrEnum / IntEnum are subclasses of str / int respectively.
+    # Check these first so that ``class Foo(StrEnum)`` is handled.
+    if issubclass(enum_cls, str):
+        return str
+    if issubclass(enum_cls, int):
+        return int
+
+    # Fallback: walk the MRO for any non-Enum builtin mixin.
+    for base in enum_cls.__mro__:
+        if base in (object, Enum, _enum_mod.Enum):
+            continue
+        if base is str:
+            return str
+        if base is int:
+            return int
+    return None
+
+
 def _build_usr_enum(enum_cls: type) -> USREnum:
     """Construct a USREnum from a Python Enum class, including any
     target-specific meta classes (PydanticMeta, SerdeMeta, ...) the user
@@ -33,6 +60,7 @@ def _build_usr_enum(enum_cls: type) -> USREnum:
     return USREnum(
         name=enum_cls.__name__,
         values=[(e.name, e.value) for e in enum_cls],
+        value_type=_detect_enum_value_type(enum_cls),
         custom_code=custom_code,
     )
 

--- a/src/schema_gen/parsers/schema_parser.py
+++ b/src/schema_gen/parsers/schema_parser.py
@@ -18,29 +18,17 @@ _ENUM_META_CLASSES = {
 
 
 def _detect_enum_value_type(enum_cls: type) -> type | None:
-    """Return the mixin base type (``str``, ``int``, …) of an Enum class.
+    """Return the value type of an Enum class when it is ``str``- or
+    ``int``-backed.
 
     Detects both explicit mixin forms (``class Foo(str, Enum)``) and
-    stdlib convenience classes (``StrEnum``, ``IntEnum``).  Returns
-    ``None`` for a plain ``Enum`` with no mixin.
+    stdlib convenience classes (``StrEnum``, ``IntEnum``). Returns
+    ``None`` for plain ``Enum`` classes or enums backed by other types.
     """
-    import enum as _enum_mod
-
-    # StrEnum / IntEnum are subclasses of str / int respectively.
-    # Check these first so that ``class Foo(StrEnum)`` is handled.
     if issubclass(enum_cls, str):
         return str
     if issubclass(enum_cls, int):
         return int
-
-    # Fallback: walk the MRO for any non-Enum builtin mixin.
-    for base in enum_cls.__mro__:
-        if base in (object, Enum, _enum_mod.Enum):
-            continue
-        if base is str:
-            return str
-        if base is int:
-            return int
     return None
 
 

--- a/tests/test_optional_enum.py
+++ b/tests/test_optional_enum.py
@@ -38,7 +38,7 @@ class TestOptionalEnumDiscovery:
 
     @staticmethod
     def _assert_pydantic_has_members(code: str) -> None:
-        assert "class OptionType(Enum):" in code, code
+        assert "class OptionType(str, Enum):" in code, code
         assert 'CE = "CE"' in code, code
         assert 'PE = "PE"' in code, code
 

--- a/tests/test_optional_enum.py
+++ b/tests/test_optional_enum.py
@@ -80,6 +80,32 @@ class TestOptionalEnumDiscovery:
         self._assert_zod_has_members(ZodGenerator().generate_file(schema))
         self._assert_jsonschema_has_members(JsonSchemaGenerator().generate_file(schema))
 
+    def test_str_enum_json_roundtrip(self):
+        """Issue #26: str,Enum mixin must survive generation so json.dumps works."""
+        import json
+
+        class OptionType(str, Enum):
+            CE = "CE"
+            PE = "PE"
+
+        @Schema
+        class WithEnum:
+            option_type: OptionType = Field(description="required")
+
+        schema = SchemaParser().parse_schema(WithEnum)
+        code = PydanticGenerator().generate_file(schema)
+
+        # Execute the generated code to verify it produces a working model.
+        ns: dict = {}
+        exec(code, ns)  # noqa: S102
+        model_cls = ns["WithEnum"]
+        instance = model_cls(option_type="CE")
+        dumped = instance.model_dump()
+        # This is the actual bug from issue #26: json.dumps must not raise
+        # TypeError on enum values when the str mixin is preserved.
+        json_str = json.dumps(dumped)
+        assert '"CE"' in json_str
+
     def test_required_enum_control_case(self):
         """Required (non-Optional) enum must continue to emit members (no regression)."""
 

--- a/tests/test_pydantic_config.py
+++ b/tests/test_pydantic_config.py
@@ -1,3 +1,7 @@
+# ruff: noqa: UP042
+# These tests deliberately use ``class X(str, Enum)`` because the bug we're
+# pinning requires this exact spelling. Rewriting to ``StrEnum`` would change
+# the code paths under test.
 """Tests for per-target Pydantic Config (Config.pydantic) wiring.
 
 These tests guard the fix that threads ``Config.pydantic`` from the engine
@@ -267,7 +271,7 @@ class TestPydanticEnumMeta:
 
         usr = SchemaParser().parse_schema(_PyOrderEvent)
         out = PydanticGenerator().generate_file(usr)
-        assert "class _PyOrderStatus(Enum):" in out
+        assert "class _PyOrderStatus(str, Enum):" in out
         assert "def is_terminal(self) -> bool:" in out
         assert "_PyOrderStatus.FILLED" in out
 
@@ -276,7 +280,7 @@ class TestPydanticEnumMeta:
 
         usr = SchemaParser().parse_schema(_PyPaint)
         out = PydanticGenerator().generate_file(usr)
-        assert "class _PyPlainColor(Enum):" in out
+        assert "class _PyPlainColor(str, Enum):" in out
         # No injected methods
         assert "def is_terminal" not in out
 


### PR DESCRIPTION
## Summary

- Add `value_type` field to `USREnum` to track `str`/`int` mixin base types
- Update schema parser to detect `str, Enum`, `int, Enum`, `StrEnum`, `IntEnum`
- Update Pydantic generator to emit `class Foo(str, Enum):` when mixin is present
- Fixes JSON serialization breakage when using `model_dump()` + `json.dumps()`

Fixes #26

## Test plan

- [x] Updated existing tests to expect `(str, Enum)` for enums defined with `str` mixin
- [x] All tests pass (1 pre-existing failure unrelated)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)