### PR TITLE
fix: emit z.string().datetime() for datetime fields in Zod generator (#27)

### DIFF
--- a/src/schema_gen/generators/zod_generator.py
+++ b/src/schema_gen/generators/zod_generator.py
@@ -315,8 +315,20 @@ class ZodGenerator(BaseGenerator):
         elif field.type == FieldType.BOOLEAN:
             return "z.boolean()"
 
-        elif field.type == FieldType.DATETIME or field.type == FieldType.DATE:
-            return "z.date()"
+        elif field.type == FieldType.DATETIME:
+            if self._zod_cfg().get("coerce", False):
+                return "z.coerce.date()"
+            return "z.string().datetime()"
+
+        elif field.type == FieldType.DATE:
+            if self._zod_cfg().get("coerce", False):
+                return "z.coerce.date()"
+            return "z.string().date()"
+
+        elif field.type == FieldType.TIME:
+            if self._zod_cfg().get("coerce", False):
+                return "z.coerce.date()"
+            return "z.string().time()"
 
         elif field.type == FieldType.UUID:
             return "z.string().uuid()"
@@ -403,7 +415,6 @@ class ZodGenerator(BaseGenerator):
         for field_def in field_defs:
             lines.append(field_def)
 
-        # TODO: support Config.zod coerce key
         strict = self._zod_cfg().get("strict", False)
         closing = "}).strict();" if strict else "});"
         lines.append(closing)
@@ -425,8 +436,10 @@ class ZodGenerator(BaseGenerator):
             return "number"
         elif field.type == FieldType.BOOLEAN:
             return "boolean"
-        elif field.type == FieldType.DATETIME or field.type == FieldType.DATE:
-            return "Date"
+        elif field.type in (FieldType.DATETIME, FieldType.DATE, FieldType.TIME):
+            if self._zod_cfg().get("coerce", False):
+                return "Date"
+            return "string"
         elif field.type == FieldType.UUID:
             return "string"
         elif field.type == FieldType.LIST or field.type in (

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -110,6 +110,10 @@ class TestAllGenerators:
         assert ".min(13).max(120)" in file_content
         assert "export type TestUser = z.infer<typeof TestUserSchema>;" in file_content
 
+        # Datetime fields should use z.string().datetime(), not z.date() (#27)
+        assert "z.string().datetime()" in file_content
+        assert "z.date()" not in file_content
+
     def test_pathway_generator(self, comprehensive_schema):
         """Test Pathway generator"""
         generator = PathwayGenerator()
@@ -1320,6 +1324,43 @@ class TestSelfReferentialTypes:
 
         # Parent should be an optional TreeNode
         assert "parent: TreeNode" in file_content
+
+    def test_zod_date_and_time_fields(self):
+        """Test that DATE and TIME field types get correct Zod types (#27)"""
+        from datetime import date, time
+
+        from schema_gen.core.config import Config
+
+        SchemaRegistry._schemas.clear()
+
+        @Schema
+        class EventTimes:
+            """Schema with date and time fields"""
+
+            event_date: date = Field(description="The event date")
+            event_time: time = Field(description="The event time")
+            event_datetime: datetime = Field(description="Full timestamp")
+
+        parser = SchemaParser()
+        schema = parser.parse_schema(EventTimes)
+
+        generator = ZodGenerator()
+        file_content = generator.generate_file(schema)
+
+        assert "z.string().date()" in file_content
+        assert "z.string().time()" in file_content
+        assert "z.string().datetime()" in file_content
+        assert "z.date()" not in file_content
+
+        # With coerce mode, all should use z.coerce.date()
+        config = Config(zod={"coerce": True})
+        generator_coerce = ZodGenerator(config=config)
+        file_content_coerce = generator_coerce.generate_file(schema)
+
+        assert file_content_coerce.count("z.coerce.date()") == 3
+        assert "z.string().date()" not in file_content_coerce
+        assert "z.string().time()" not in file_content_coerce
+        assert "z.string().datetime()" not in file_content_coerce
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Change `FieldType.DATETIME` from `z.date()` to `z.string().datetime()`
- Change `FieldType.DATE` from `z.date()` to `z.string().date()`
- Add `FieldType.TIME` as `z.string().time()` (was falling through to `z.any()`)
- When `Config.zod["coerce"]` is `True`, emit `z.coerce.date()` for all three
- Update TypeScript type from `Date` to `string` (matches the new Zod types)

Fixes #27

## Test plan

- [x] Added assertions to existing `test_zod_generator` verifying `z.string().datetime()`
- [x] Added `test_zod_date_and_time_fields` covering all three types in default and coerce modes
- [x] All tests pass, pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)