### PR TITLE
feat: add --format github for GitHub Actions annotations (#23)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -162,7 +162,7 @@ schema-gen diff [OPTIONS]
   - `.git#commit=abc123` — compare against a specific commit
   - `/path/to/snapshot/` — compare against a directory of JSON Schema files
 - `--level [WIRE|WIRE_JSON|SOURCE]` - Strictness level (default: `WIRE_JSON`)
-- `--format [text|json]` - Output format (default: `text`)
+- `--format [text|json|github]` - Output format (default: `text`)
 - `--ignore TEXT` - Suppress a specific rule (repeatable)
 - `-c, --config TEXT` - Path to config file (default: `.schema-gen.config.py`)
 
@@ -180,6 +180,9 @@ schema-gen diff --against .git#tag=v1.0.0 --level WIRE
 
 # JSON output for CI parsing
 schema-gen diff --against .git#branch=main --format json
+
+# GitHub Actions annotations (inline PR comments)
+schema-gen diff --against .git#branch=main --format github
 
 # Suppress a known intentional break
 schema-gen diff --against .git#branch=main --ignore FIELD_NO_DELETE

--- a/src/schema_gen/cli/main.py
+++ b/src/schema_gen/cli/main.py
@@ -11,7 +11,7 @@ from watchdog.observers import Observer
 from ..core.generator import create_generation_engine
 from ..diff.baseline import BaselineError, load_baseline, load_current
 from ..diff.comparator import compare_schemas
-from ..diff.formatter import format_json, format_text
+from ..diff.formatter import format_github, format_json, format_text
 from ..diff.rules import RuleId, StrictnessLevel
 
 # Pattern to match timestamp lines across all generators
@@ -539,7 +539,7 @@ def install_hooks(install_pre_commit):
 @click.option(
     "--format",
     "fmt",
-    type=click.Choice(["text", "json"], case_sensitive=False),
+    type=click.Choice(["text", "json", "github"], case_sensitive=False),
     default="text",
     help="Output format [default: text]",
 )
@@ -597,6 +597,8 @@ def diff(against, level, fmt, ignore_rules, config_path):
         if violations:
             if fmt == "json":
                 click.echo(format_json(violations))
+            elif fmt == "github":
+                click.echo(format_github(violations))
             else:
                 click.echo(format_text(violations))
             raise SystemExit(1)

--- a/src/schema_gen/diff/__init__.py
+++ b/src/schema_gen/diff/__init__.py
@@ -1,7 +1,7 @@
 """Breaking change detection for schema-gen schemas."""
 
 from .comparator import compare_schemas
-from .formatter import format_json, format_text
+from .formatter import format_github, format_json, format_text
 from .rules import RuleId, StrictnessLevel, Violation
 
 __all__ = [
@@ -11,4 +11,5 @@ __all__ = [
     "compare_schemas",
     "format_text",
     "format_json",
+    "format_github",
 ]

--- a/src/schema_gen/diff/formatter.py
+++ b/src/schema_gen/diff/formatter.py
@@ -39,3 +39,20 @@ def format_json(violations: list[Violation]) -> str:
         for v in violations
     ]
     return json.dumps(items, indent=2)
+
+
+def format_github(violations: list[Violation]) -> str:
+    """Format violations as GitHub Actions workflow commands.
+
+    Emits ``::error`` annotations that render as inline PR comments
+    when the workflow runs on a pull request.
+    """
+    lines: list[str] = []
+    for v in violations:
+        location = v.schema_name
+        if v.field_name:
+            location = f"{v.schema_name}.{v.field_name}"
+        # GitHub Actions workflow command format:
+        # ::error title=RULE::message
+        lines.append(f"::error title={v.rule_id.value} ({location})::{v.message}")
+    return "\n".join(lines)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -8,7 +8,7 @@ from click.testing import CliRunner
 
 from schema_gen.cli.main import main
 from schema_gen.diff.comparator import compare_schemas
-from schema_gen.diff.formatter import format_json, format_text
+from schema_gen.diff.formatter import format_github, format_json, format_text
 from schema_gen.diff.rules import RuleId, StrictnessLevel, Violation
 
 # ---------------------------------------------------------------------------
@@ -494,6 +494,47 @@ class TestFormatJson:
         assert result[0]["field"] == "age"
 
 
+class TestFormatGithub:
+    def test_empty(self):
+        assert format_github([]) == ""
+
+    def test_single_violation(self):
+        v = Violation(
+            rule_id=RuleId.FIELD_NO_DELETE,
+            schema_name="User",
+            field_name="age",
+            message="Field 'age' was deleted from 'User'",
+            level=StrictnessLevel.WIRE,
+        )
+        output = format_github([v])
+        assert output.startswith("::error ")
+        assert "FIELD_NO_DELETE" in output
+        assert "User.age" in output
+        assert "Field 'age' was deleted from 'User'" in output
+
+    def test_multiple_violations(self):
+        vs = [
+            Violation(
+                rule_id=RuleId.FIELD_NO_DELETE,
+                schema_name="User",
+                field_name="age",
+                message="deleted",
+                level=StrictnessLevel.WIRE,
+            ),
+            Violation(
+                rule_id=RuleId.TYPE_NO_DELETE,
+                schema_name="Order",
+                field_name=None,
+                message="removed",
+                level=StrictnessLevel.WIRE,
+            ),
+        ]
+        output = format_github(vs)
+        lines = output.strip().splitlines()
+        assert len(lines) == 2
+        assert all(line.startswith("::error ") for line in lines)
+
+
 # ---------------------------------------------------------------------------
 # CLI tests
 # ---------------------------------------------------------------------------
@@ -558,6 +599,25 @@ class TestDiffCLI:
         parsed = json.loads(result.output)
         assert len(parsed) >= 1
         assert parsed[0]["rule"] == "FIELD_NO_DELETE"
+
+    @patch("schema_gen.cli.main.create_generation_engine")
+    @patch("schema_gen.cli.main.load_current")
+    @patch("schema_gen.cli.main.load_baseline")
+    def test_diff_github_format(self, mock_baseline, mock_current, mock_engine):
+        mock_engine.return_value.config.output_dir = "generated/"
+        old_schema = _schema_file(
+            {"User": _type_def(properties={"name": {"type": "string"}})}
+        )
+        new_schema = _schema_file({"User": _type_def(properties={})})
+        mock_baseline.return_value = {"user.json": old_schema}
+        mock_current.return_value = {"user.json": new_schema}
+
+        result = self.runner.invoke(
+            main, ["diff", "--against", ".git#branch=main", "--format", "github"]
+        )
+        assert result.exit_code == 1
+        assert "::error " in result.output
+        assert "FIELD_NO_DELETE" in result.output
 
     @patch("schema_gen.cli.main.create_generation_engine")
     @patch("schema_gen.cli.main.load_current")


### PR DESCRIPTION
## Summary

Adds `--format github` to `schema-gen diff` that emits `::error` workflow commands, rendering as inline PR comments when run in GitHub Actions.

```yaml
- name: Schema breaking change detection
  run: schema-gen diff --against .git#branch=main --format github
```

This completes the last acceptance criterion for #23.

Closes #23

## Test plan

- [x] 4 new tests: `format_github` empty/single/multiple + CLI `--format github`
- [x] All 60 diff tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)