### PR TITLE
fix: deduplicate enum re-exports in Zod index.ts (#37)

### DIFF
--- a/src/schema_gen/generators/zod_generator.py
+++ b/src/schema_gen/generators/zod_generator.py
@@ -85,6 +85,10 @@ class ZodGenerator(BaseGenerator):
         types are re-exported via ``export type`` so that projects using
         ``verbatimModuleSyntax`` don't trip TS1205 on the type-only names
         (POC finding C5).
+
+        Each name is exported at most once (from the first module that
+        declares it) to avoid ``Duplicate identifier`` TS errors when
+        multiple schema files reference the same enum.
         """
         lines = [
             "/**",
@@ -94,25 +98,50 @@ class ZodGenerator(BaseGenerator):
             "",
         ]
 
+        # Track names already emitted so shared enums are only exported once.
+        exported_value_names: set[str] = set()
+        exported_type_names: set[str] = set()
+
         for schema in schemas:
             module = f"./{schema.name.lower()}"
             # Collect runtime (value) names — schemas themselves.
-            value_names = [f"{e.name}Schema" for e in schema.enums]
-            value_names.append(f"{schema.name}Schema")
-            value_names.extend(
-                f"{self._variant_to_schema_name(schema.name, v)}Schema"
-                for v in schema.variants
-            )
+            value_names: list[str] = []
+            for e in schema.enums:
+                name = f"{e.name}Schema"
+                if name not in exported_value_names:
+                    value_names.append(name)
+                    exported_value_names.add(name)
+            schema_val = f"{schema.name}Schema"
+            if schema_val not in exported_value_names:
+                value_names.append(schema_val)
+                exported_value_names.add(schema_val)
+            for v in schema.variants:
+                variant_val = f"{self._variant_to_schema_name(schema.name, v)}Schema"
+                if variant_val not in exported_value_names:
+                    value_names.append(variant_val)
+                    exported_value_names.add(variant_val)
 
             # Collect type-only names — inferred TS types.
-            type_names = [e.name for e in schema.enums]
-            type_names.append(schema.name)
-            type_names.extend(
-                self._variant_to_schema_name(schema.name, v) for v in schema.variants
-            )
+            type_names: list[str] = []
+            for e in schema.enums:
+                if e.name not in exported_type_names:
+                    type_names.append(e.name)
+                    exported_type_names.add(e.name)
+            if schema.name not in exported_type_names:
+                type_names.append(schema.name)
+                exported_type_names.add(schema.name)
+            for v in schema.variants:
+                variant_type = self._variant_to_schema_name(schema.name, v)
+                if variant_type not in exported_type_names:
+                    type_names.append(variant_type)
+                    exported_type_names.add(variant_type)
 
-            lines.append(f"export {{ {', '.join(value_names)} }} from '{module}';")
-            lines.append(f"export type {{ {', '.join(type_names)} }} from '{module}';")
+            if value_names:
+                lines.append(f"export {{ {', '.join(value_names)} }} from '{module}';")
+            if type_names:
+                lines.append(
+                    f"export type {{ {', '.join(type_names)} }} from '{module}';"
+                )
 
         return "\n".join(lines) + "\n"
 

--- a/tests/test_zod_imports.py
+++ b/tests/test_zod_imports.py
@@ -1,6 +1,9 @@
-"""Zod cross-file import + index re-export tests (POC findings C4, C5)."""
+"""Zod cross-file import + index re-export tests (POC findings C4, C5, #37)."""
 
 from __future__ import annotations
+
+import re
+from enum import Enum as PyEnum
 
 from schema_gen import Schema
 from schema_gen.core.config import Config
@@ -81,3 +84,75 @@ class TestZodIndexExportType:
         # ...and the inferred types are re-exported via `export type`.
         assert "export type { _ZodFoo } from './_zodfoo';" in index
         assert "export type { _ZodBar } from './_zodbar';" in index
+
+
+# -- Shared enum used by two schemas for duplicate-export test (#37) --------
+
+
+class _SharedOptionType(PyEnum):
+    CE = "CE"
+    PE = "PE"
+
+
+@Schema
+class _ZodOrderRequest:
+    order_id: str
+    option_type: _SharedOptionType
+
+
+@Schema
+class _ZodPositionLeg:
+    leg_id: int
+    option_type: _SharedOptionType
+
+
+class TestZodDuplicateExports:
+    """Fix #37: shared enums must not produce duplicate re-exports in index.ts."""
+
+    def test_shared_enum_exported_once(self, tmp_path):
+        _reregister(_ZodOrderRequest, _ZodPositionLeg)
+
+        out_dir = tmp_path / "out"
+        config = Config(
+            input_dir=str(tmp_path / "schemas"),
+            output_dir=str(out_dir),
+            targets=["zod"],
+        )
+        SchemaGenerationEngine(config).generate_all()
+
+        index = (out_dir / "zod" / "index.ts").read_text()
+
+        # The enum value export should appear exactly once.
+        assert index.count("_SharedOptionTypeSchema") == 1
+        # The enum type export should appear exactly once.
+        assert index.count("_SharedOptionType") == 2  # once value, once type
+
+        # Both model schemas should still be exported.
+        assert "_ZodOrderRequestSchema" in index
+        assert "_ZodPositionLegSchema" in index
+
+    def test_no_duplicate_identifier_lines(self, tmp_path):
+        """Every exported name must appear in at most one export statement."""
+        _reregister(_ZodOrderRequest, _ZodPositionLeg)
+
+        out_dir = tmp_path / "out"
+        config = Config(
+            input_dir=str(tmp_path / "schemas"),
+            output_dir=str(out_dir),
+            targets=["zod"],
+        )
+        SchemaGenerationEngine(config).generate_all()
+
+        index = (out_dir / "zod" / "index.ts").read_text()
+
+        # Extract all exported names (value + type) across all lines.
+        exported: list[str] = re.findall(r"(?:export|export type)\s*\{([^}]+)\}", index)
+        all_names: list[str] = []
+        for group in exported:
+            all_names.extend(name.strip() for name in group.split(","))
+
+        # No name should appear more than once.
+        seen: set[str] = set()
+        for name in all_names:
+            assert name not in seen, f"Duplicate export: {name}"
+            seen.add(name)


### PR DESCRIPTION
## Summary

When multiple schema files reference the same enum, the generated `index.ts` was re-exporting it from each module, causing TypeScript `Duplicate identifier` errors. Now tracks exported names and skips duplicates.

Fixes #37

## Test plan

- [x] Two new tests verifying shared enums are exported exactly once
- [x] All tests pass, pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)