### PR TITLE
fix: remove unused import type lines in Zod generator (#38)

### DIFF
--- a/src/schema_gen/generators/zod_generator.py
+++ b/src/schema_gen/generators/zod_generator.py
@@ -514,14 +514,15 @@ class ZodGenerator(BaseGenerator):
         ]
 
         # Cross-file imports for nested schema references (POC finding C4).
-        # We import both the runtime schema (value) and the inferred type.
-        # `import type` avoids TS1205 in projects with verbatimModuleSyntax.
+        # We only import the runtime Zod schema (value).  The inferred TS
+        # types are derived via ``z.infer<typeof …Schema>`` so a separate
+        # ``import type`` is unnecessary and triggers TS6133 when
+        # ``noUnusedLocals`` is enabled (#38).
         for ref in sorted(external_refs):
             if ref == schema_name:
                 continue  # self-ref is handled via z.lazy()
             module = ref.lower()
             lines.append(f"import {{ {ref}Schema }} from './{module}';")
-            lines.append(f"import type {{ {ref} }} from './{module}';")
 
         lines.append("")
 

--- a/tests/test_zod_imports.py
+++ b/tests/test_zod_imports.py
@@ -55,8 +55,12 @@ class TestZodCrossFileImports:
         SchemaGenerationEngine(config).generate_all()
 
         order_ts = (out_dir / "zod" / "_zodorderreq.ts").read_text()
+        # Runtime schema import must be present (value, not type).
         assert "import { _ZodExecCtxSchema } from './_zodexecctx';" in order_ts
-        assert "import type { _ZodExecCtx } from './_zodexecctx';" in order_ts
+        # Type-only import must NOT be emitted — the inferred type is
+        # derived via z.infer<typeof …Schema>, so a separate import type
+        # is unused and triggers TS6133 with noUnusedLocals (#38).
+        assert "import type { _ZodExecCtx } from './_zodexecctx';" not in order_ts
 
 
 class TestZodIndexExportType:


### PR DESCRIPTION
## Summary

The Zod generator emitted `import type { Foo } from './bar'` for cross-file schema references, but these types were never used — all TypeScript types are derived via `z.infer<typeof FooSchema>`. Removed the unused import lines to fix `TS6133` errors with `noUnusedLocals: true`.

Fixes #38

## Test plan

- [x] Updated existing cross-file import test to verify no `import type` lines
- [x] All tests pass, pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)