### PR TITLE
fix: use file-relative $ref for cross-file nested types in JSON Schema (#41)

### DIFF
--- a/src/schema_gen/generators/jsonschema_generator.py
+++ b/src/schema_gen/generators/jsonschema_generator.py
@@ -36,6 +36,13 @@ class JsonSchemaGenerator(BaseGenerator):
         )
         cfg_base_url = js_cfg.get("base_url")
         self.base_url = (cfg_base_url or base_url).rstrip("/")
+
+        # Set of definition names present in the current file's ``$defs``.
+        # Populated by ``generate_file()`` so that ``_add_type_info`` can
+        # decide whether a nested schema ``$ref`` should be local
+        # (``#/$defs/Foo``) or file-relative (``foo.json#/$defs/Foo``).
+        self._current_defs: set[str] = set()
+
         # Warn on unknown Config.jsonschema keys.
         for key in js_cfg:
             if key not in _SUPPORTED_JSONSCHEMA_CONFIG_KEYS:
@@ -134,32 +141,45 @@ class JsonSchemaGenerator(BaseGenerator):
             "$defs": {},
         }
 
-        # Add enum definitions to $defs
+        # Pre-compute the set of names that will appear in this file's $defs
+        # so that _add_type_info can distinguish local vs cross-file $refs.
+        self._current_defs = {schema.name}
         for enum_def in getattr(schema, "enums", []):
-            enum_values = [v for _name, v in enum_def.values]
-            enum_schema = {"type": "string", "enum": enum_values}
-            json_schema["$defs"][enum_def.name] = enum_schema
-
-        # Add base schema
-        base_fields = schema.fields
-        base_schema = self._generate_schema_definition(
-            schema.name, schema.description, base_fields
-        )
-        json_schema["$defs"][schema.name] = base_schema
-
-        # Add variants
+            self._current_defs.add(enum_def.name)
         for variant_name in schema.variants:
-            variant_fields = schema.get_variant_fields(variant_name)
-            variant_title = self._variant_to_schema_title(schema.name, variant_name)
-            variant_schema = self._generate_schema_definition(
-                variant_title, schema.description, variant_fields
+            self._current_defs.add(
+                self._variant_to_schema_title(schema.name, variant_name)
             )
-            json_schema["$defs"][variant_title] = variant_schema
 
-        # Set the main schema to reference the base schema
-        json_schema["$ref"] = f"#/$defs/{schema.name}"
+        try:
+            # Add enum definitions to $defs
+            for enum_def in getattr(schema, "enums", []):
+                enum_values = [v for _name, v in enum_def.values]
+                enum_schema = {"type": "string", "enum": enum_values}
+                json_schema["$defs"][enum_def.name] = enum_schema
 
-        return json.dumps(json_schema, indent=2)
+            # Add base schema
+            base_fields = schema.fields
+            base_schema = self._generate_schema_definition(
+                schema.name, schema.description, base_fields
+            )
+            json_schema["$defs"][schema.name] = base_schema
+
+            # Add variants
+            for variant_name in schema.variants:
+                variant_fields = schema.get_variant_fields(variant_name)
+                variant_title = self._variant_to_schema_title(schema.name, variant_name)
+                variant_schema = self._generate_schema_definition(
+                    variant_title, schema.description, variant_fields
+                )
+                json_schema["$defs"][variant_title] = variant_schema
+
+            # Set the main schema to reference the base schema
+            json_schema["$ref"] = f"#/$defs/{schema.name}"
+
+            return json.dumps(json_schema, indent=2)
+        finally:
+            self._current_defs = set()
 
     def _generate_schema_definition(
         self, title: str, description: str, fields: list[USRField]
@@ -303,7 +323,15 @@ class JsonSchemaGenerator(BaseGenerator):
             field_schema["$ref"] = f"#/$defs/{field.enum_name}"
 
         elif field.type == FieldType.NESTED_SCHEMA:
-            field_schema["$ref"] = f"#/$defs/{field.nested_schema}"
+            nested = field.nested_schema
+            if not self._current_defs or nested in self._current_defs:
+                # Local reference (same file or standalone generate_model call)
+                field_schema["$ref"] = f"#/$defs/{nested}"
+            else:
+                # Cross-file reference: point to the other schema's file
+                field_schema["$ref"] = (
+                    f"{nested.lower()}{self.file_extension}#/$defs/{nested}"
+                )
 
         else:
             # Default to allowing any type

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1300,6 +1300,72 @@ class TestSelfReferentialTypes:
         parent_prop = tree_def["properties"]["parent"]
         assert parent_prop["$ref"] == "#/$defs/TreeNode"
 
+    def test_jsonschema_cross_file_ref(self):
+        """Test that JSON Schema $ref points to external file for cross-file nested types"""
+        from schema_gen.core.usr import FieldType, USRField, USRSchema
+
+        # SignalLeg is defined in a separate schema file
+        signal_leg_schema = USRSchema(
+            name="SignalLeg",
+            fields=[
+                USRField(name="symbol", type=FieldType.STRING, python_type=str),
+                USRField(name="weight", type=FieldType.FLOAT, python_type=float),
+            ],
+            description="A single leg of a signal",
+        )
+
+        # ExecutionPlan references SignalLeg as a nested field
+        execution_plan_schema = USRSchema(
+            name="ExecutionPlan",
+            fields=[
+                USRField(name="name", type=FieldType.STRING, python_type=str),
+                USRField(
+                    name="leg",
+                    type=FieldType.NESTED_SCHEMA,
+                    python_type=object,
+                    nested_schema="SignalLeg",
+                ),
+                USRField(
+                    name="legs",
+                    type=FieldType.LIST,
+                    python_type=list,
+                    inner_type=USRField(
+                        name="legs_item",
+                        type=FieldType.NESTED_SCHEMA,
+                        python_type=object,
+                        nested_schema="SignalLeg",
+                    ),
+                ),
+            ],
+            description="An execution plan referencing signal legs",
+        )
+
+        generator = JsonSchemaGenerator()
+
+        # Generate the ExecutionPlan file — SignalLeg is NOT in its $defs
+        ep_content = generator.generate_file(execution_plan_schema)
+        ep_data = json.loads(ep_content)
+
+        # SignalLeg should NOT appear in ExecutionPlan's $defs
+        assert "SignalLeg" not in ep_data["$defs"]
+        assert "ExecutionPlan" in ep_data["$defs"]
+
+        ep_def = ep_data["$defs"]["ExecutionPlan"]
+
+        # Direct nested field should use file-relative $ref
+        leg_prop = ep_def["properties"]["leg"]
+        assert leg_prop["$ref"] == "signalleg.json#/$defs/SignalLeg"
+
+        # Nested field inside a list should also use file-relative $ref
+        legs_prop = ep_def["properties"]["legs"]
+        assert legs_prop["type"] == "array"
+        assert legs_prop["items"]["$ref"] == "signalleg.json#/$defs/SignalLeg"
+
+        # Verify the SignalLeg file itself uses local $ref for self
+        sl_content = generator.generate_file(signal_leg_schema)
+        sl_data = json.loads(sl_content)
+        assert "SignalLeg" in sl_data["$defs"]
+
     def test_zod_self_reference(self, tree_node_schema):
         """Test that Zod generator uses z.lazy() for self-referential fields"""
         generator = ZodGenerator()


### PR DESCRIPTION
## Summary

When a schema references a nested `@Schema` type defined in another file, the JSON Schema generator now emits file-relative `$ref` (e.g., `"signalleg.json#/$defs/SignalLeg"`) instead of broken local `$ref` (`"#/$defs/SignalLeg"`).

Self-references and enums in the same file continue to use local `$ref`.

Fixes #41

## Test plan

- [x] New `test_jsonschema_cross_file_ref` — verifies cross-file refs for direct and list fields
- [x] Existing `test_jsonschema_self_reference` still passes (local refs unchanged)
- [x] All tests pass, pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)