### PR TITLE
fix: extract shared enums to _enums.py in Pydantic generator (#43)

### DIFF
--- a/src/schema_gen/generators/pydantic_generator.py
+++ b/src/schema_gen/generators/pydantic_generator.py
@@ -31,6 +31,11 @@ class PydanticGenerator(BaseGenerator):
     def __init__(self, config: Config | None = None) -> None:
         super().__init__(config=config)
         self.template = Template(self._get_template())
+        #: Set of enum names that have been extracted to ``_enums.py``.
+        #: Populated by ``get_extra_files()`` before ``generate_file()``
+        #: is called so that per-schema files can import instead of
+        #: re-declaring the enum inline.
+        self._shared_enum_names: set[str] = set()
 
     def _get_model_config_line(self) -> str:
         """Build the ``model_config = ConfigDict(...)`` line.
@@ -68,32 +73,107 @@ class PydanticGenerator(BaseGenerator):
     def get_schema_filename(self, schema: USRSchema) -> str:
         return f"{schema.name.lower()}_models.py"
 
+    def get_extra_files(
+        self, schemas: list[USRSchema], output_dir: Path
+    ) -> dict[str, str]:
+        """Emit ``_enums.py`` containing all enums across all schemas.
+
+        Enums are de-duplicated by name so that multiple schemas referencing
+        the same enum (e.g. ``OptionType``) share a single definition.
+        Per-schema files import from ``._enums`` instead of declaring enums
+        inline, which prevents duplicate class definitions across modules.
+        """
+        # Collect unique enums across all schemas (first-seen wins).
+        seen: dict[str, Any] = {}  # enum_name -> USREnum
+        for schema in schemas:
+            for enum_def in schema.enums:
+                if enum_def.name not in seen:
+                    seen[enum_def.name] = enum_def
+
+        if not seen:
+            self._shared_enum_names = set()
+            return {}
+
+        self._shared_enum_names = set(seen.keys())
+
+        # Build _enums.py content
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC")
+        lines = [
+            '"""',
+            "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY",
+            "Shared enum definitions for generated Pydantic models",
+            f"Generated at: {timestamp}",
+            "Generator: schema-gen Pydantic generator",
+            "",
+            "To regenerate this file, run:",
+            "    schema-gen generate --target pydantic",
+            "",
+            "Changes to this file will be overwritten.",
+            '"""',
+            "",
+            "from enum import Enum",
+            "",
+        ]
+
+        for enum_def in seen.values():
+            lines.append("")
+            if enum_def.value_type is not None:
+                mixin_name = enum_def.value_type.__name__
+                lines.append(f"class {enum_def.name}({mixin_name}, Enum):")
+            else:
+                lines.append(f"class {enum_def.name}(Enum):")
+            for member_name, member_value in enum_def.values:
+                if isinstance(member_value, str):
+                    lines.append(f'    {member_name} = "{member_value}"')
+                else:
+                    lines.append(f"    {member_name} = {member_value}")
+
+            # Inject custom methods from PydanticMeta
+            enum_meta = (enum_def.custom_code or {}).get("pydantic", {}) or {}
+            methods_src = (enum_meta.get("methods") or "").strip()
+            if methods_src:
+                lines.append("")
+                for method_line in methods_src.splitlines():
+                    if method_line.strip():
+                        lines.append(f"    {method_line}")
+                    else:
+                        lines.append("")
+
+        lines.append("")
+        return {"_enums.py": "\n".join(lines) + "\n"}
+
     def generate_index(self, schemas: list[USRSchema], output_dir: Path) -> str | None:
         """Generate __init__.py content for the pydantic package."""
         lines = ['"""Generated Pydantic models"""\n']
 
+        # Import shared enums from _enums module (de-duplicated)
+        if self._shared_enum_names:
+            sorted_enums = sorted(self._shared_enum_names)
+            lines.append(f"from ._enums import {', '.join(sorted_enums)}")
+
         for schema in schemas:
-            enum_classes = [e.name for e in schema.enums]
+            # Enum classes now come from _enums, so only import models
             base_class = schema.name
             variant_classes = [
                 self._variant_to_class_name(schema.name, v) for v in schema.variants
             ]
-            all_classes = enum_classes + [base_class] + variant_classes
+            model_classes = [base_class] + variant_classes
             lines.append(
-                f"from .{schema.name.lower()}_models import {', '.join(all_classes)}"
+                f"from .{schema.name.lower()}_models import {', '.join(model_classes)}"
             )
 
-        lines.append("\n__all__ = [")
+        # Build __all__ with enums first, then models
+        all_names: list[str] = sorted(self._shared_enum_names)
         for schema in schemas:
-            enum_classes = [e.name for e in schema.enums]
             base_class = schema.name
             variant_classes = [
                 self._variant_to_class_name(schema.name, v) for v in schema.variants
             ]
-            all_classes = [
-                f'"{c}"' for c in enum_classes + [base_class] + variant_classes
-            ]
-            lines.append(f"    {', '.join(all_classes)},")
+            all_names.extend([base_class] + variant_classes)
+
+        lines.append("\n__all__ = [")
+        for name in all_names:
+            lines.append(f'    "{name}",')
         lines.append("]")
 
         return "\n".join(lines) + "\n"
@@ -539,9 +619,22 @@ class PydanticGenerator(BaseGenerator):
             "",
         ]
 
-        # Add enum import if we have enums
-        if enums:
+        # Determine which enums to import vs inline.
+        # When get_extra_files() has run (multi-schema generation), enums
+        # live in _enums.py and we import them. For single-schema usage
+        # (e.g. generate_file() called directly in tests without prior
+        # get_extra_files()), we fall back to inline declaration.
+        enums_to_import = [e for e in enums if e.name in self._shared_enum_names]
+        enums_to_inline = [e for e in enums if e.name not in self._shared_enum_names]
+
+        # Add enum import if we have inline enums
+        if enums_to_inline:
             lines.append("from enum import Enum")
+
+        # Add import from _enums module for shared enums
+        if enums_to_import:
+            enum_names = sorted(e.name for e in enums_to_import)
+            lines.append(f"from ._enums import {', '.join(enum_names)}")
 
         # Add custom imports from Meta.imports
         custom_imports = custom_code.get("imports", [])
@@ -587,8 +680,8 @@ class PydanticGenerator(BaseGenerator):
 
         lines.append("")
 
-        # Generate enum classes before models
-        for enum_def in enums:
+        # Generate inline enum classes before models (only enums NOT in _enums.py)
+        for enum_def in enums_to_inline:
             lines.append("")
             # Preserve the mixin base type (str, int) when the source enum
             # inherits from it — e.g. ``class Foo(str, Enum):``.

--- a/tests/test_shared_enums.py
+++ b/tests/test_shared_enums.py
@@ -1,0 +1,133 @@
+# ruff: noqa: UP042, UP045
+"""Tests for issue #43: shared enums extracted to _enums.py.
+
+When multiple @Schema classes reference the same enum, the Pydantic generator
+must declare the enum once in ``_enums.py`` and import it in each per-schema
+module — not duplicate the class in every file.
+"""
+
+from enum import Enum
+from pathlib import Path
+
+from schema_gen import Field, Schema
+from schema_gen.core.schema import SchemaRegistry
+from schema_gen.generators.pydantic_generator import PydanticGenerator
+from schema_gen.parsers.schema_parser import SchemaParser
+
+
+class TestSharedEnums:
+    """Issue #43: shared enums must live in _enums.py, not duplicated."""
+
+    def setup_method(self):
+        SchemaRegistry._schemas.clear()
+
+    def _make_schemas(self):
+        """Create two schemas that share the same enum."""
+
+        class OptionType(str, Enum):
+            CE = "CE"
+            PE = "PE"
+
+        @Schema
+        class OrderRequest:
+            option_type: OptionType = Field(description="option type")
+
+        @Schema
+        class PositionLeg:
+            option_type: OptionType = Field(description="leg option type")
+
+        parser = SchemaParser()
+        return [parser.parse_schema(OrderRequest), parser.parse_schema(PositionLeg)]
+
+    def test_get_extra_files_emits_enums_py(self):
+        """get_extra_files() should produce _enums.py with all enums."""
+        schemas = self._make_schemas()
+        gen = PydanticGenerator()
+        extra = gen.get_extra_files(schemas, Path("/tmp/out"))
+
+        assert "_enums.py" in extra
+        content = extra["_enums.py"]
+
+        # Enum is declared exactly once in _enums.py
+        assert "class OptionType(str, Enum):" in content
+        assert content.count("class OptionType") == 1
+        assert 'CE = "CE"' in content
+        assert 'PE = "PE"' in content
+
+    def test_per_schema_file_imports_enum(self):
+        """Per-schema files must import from ._enums, not declare inline."""
+        schemas = self._make_schemas()
+        gen = PydanticGenerator()
+
+        # Simulate the generation pipeline: extra files first, then per-schema
+        gen.get_extra_files(schemas, Path("/tmp/out"))
+
+        for schema in schemas:
+            code = gen.generate_file(schema)
+            # Must import from _enums
+            assert "from ._enums import OptionType" in code, (
+                f"Schema {schema.name} should import OptionType from _enums"
+            )
+            # Must NOT declare the enum class inline
+            assert "class OptionType" not in code, (
+                f"Schema {schema.name} should not declare OptionType inline"
+            )
+            # Must NOT import Enum (no inline enums)
+            assert "from enum import Enum" not in code, (
+                f"Schema {schema.name} should not import Enum stdlib"
+            )
+
+    def test_index_re_exports_enums(self):
+        """__init__.py must re-export enums from _enums module."""
+        schemas = self._make_schemas()
+        gen = PydanticGenerator()
+        gen.get_extra_files(schemas, Path("/tmp/out"))
+
+        index = gen.generate_index(schemas, Path("/tmp/out"))
+        assert index is not None
+
+        # Enum imported from _enums, not from per-schema modules
+        assert "from ._enums import OptionType" in index
+        assert '"OptionType"' in index
+
+    def test_single_schema_still_inlines_enum(self):
+        """When generate_file() is called without get_extra_files(), enum is inlined."""
+
+        class OptionType(str, Enum):
+            CE = "CE"
+            PE = "PE"
+
+        @Schema
+        class Solo:
+            option_type: OptionType = Field(description="type")
+
+        schema = SchemaParser().parse_schema(Solo)
+        gen = PydanticGenerator()
+        # Do NOT call get_extra_files — simulates direct single-schema usage
+        code = gen.generate_file(schema)
+
+        # Should inline the enum
+        assert "class OptionType(str, Enum):" in code
+        assert 'CE = "CE"' in code
+
+    def test_enum_dedup_across_schemas(self):
+        """Same enum name appearing in multiple schemas produces one entry."""
+        schemas = self._make_schemas()
+        gen = PydanticGenerator()
+        extra = gen.get_extra_files(schemas, Path("/tmp/out"))
+        content = extra["_enums.py"]
+
+        # Only one class definition
+        assert content.count("class OptionType") == 1
+
+    def test_no_enums_no_extra_file(self):
+        """Schemas with no enums should not produce _enums.py."""
+
+        @Schema
+        class Plain:
+            name: str = Field(description="name")
+
+        schema = SchemaParser().parse_schema(Plain)
+        gen = PydanticGenerator()
+        extra = gen.get_extra_files([schema], Path("/tmp/out"))
+        assert extra == {}


### PR DESCRIPTION
## Summary

When multiple schemas reference the same enum, the Pydantic generator now:
1. Generates all enums once in `_enums.py`
2. Imports them in per-schema modules via `from ._enums import EnumName`
3. Re-exports from `__init__.py` via `._enums`

This ensures `isinstance` and identity checks work across modules.

Backward compatible: direct `generate_file()` calls without the pipeline still inline enums.

Fixes #43

## Test plan

- [x] 6 new tests covering dedup, imports, index re-exports, backward compat
- [x] All tests pass (1 pre-existing failure unrelated)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)