### PR TITLE
fix: validate enum name collisions in shared enum extraction

### DIFF
--- a/src/schema_gen/generators/pydantic_generator.py
+++ b/src/schema_gen/generators/pydantic_generator.py
@@ -8,7 +8,7 @@ from typing import Any
 from jinja2 import Template
 
 from ..core.config import Config
-from ..core.usr import FieldType, USRField, USRSchema
+from ..core.usr import FieldType, USREnum, USRField, USRSchema
 from .base import BaseGenerator
 
 #: Pydantic ``ConfigDict`` keys honored by ``Config.pydantic``. Any other
@@ -84,11 +84,18 @@ class PydanticGenerator(BaseGenerator):
         inline, which prevents duplicate class definitions across modules.
         """
         # Collect unique enums across all schemas (first-seen wins).
-        seen: dict[str, Any] = {}  # enum_name -> USREnum
+        seen: dict[str, USREnum] = {}
         for schema in schemas:
             for enum_def in schema.enums:
                 if enum_def.name not in seen:
                     seen[enum_def.name] = enum_def
+                elif enum_def.values != seen[enum_def.name].values:
+                    raise ValueError(
+                        f"Enum name collision: '{enum_def.name}' is defined "
+                        f"with different members in multiple schemas. "
+                        f"First: {seen[enum_def.name].values}, "
+                        f"second: {enum_def.values}"
+                    )
 
         if not seen:
             self._shared_enum_names = set()

--- a/tests/test_shared_enums.py
+++ b/tests/test_shared_enums.py
@@ -120,6 +120,49 @@ class TestSharedEnums:
         # Only one class definition
         assert content.count("class OptionType") == 1
 
+    def test_name_collision_different_values_raises(self):
+        """Same enum name with different members must raise ValueError."""
+        import pytest
+
+        from schema_gen.core.usr import FieldType, USREnum, USRField, USRSchema
+
+        enum_a = USREnum(
+            name="Status",
+            values=[("OPEN", "open"), ("CLOSED", "closed")],
+        )
+        enum_b = USREnum(
+            name="Status",
+            values=[("ACTIVE", "active"), ("INACTIVE", "inactive")],
+        )
+        schema_a = USRSchema(
+            name="Order",
+            fields=[
+                USRField(
+                    name="status",
+                    type=FieldType.ENUM,
+                    python_type=str,
+                    enum_name="Status",
+                )
+            ],
+            enums=[enum_a],
+        )
+        schema_b = USRSchema(
+            name="Position",
+            fields=[
+                USRField(
+                    name="status",
+                    type=FieldType.ENUM,
+                    python_type=str,
+                    enum_name="Status",
+                )
+            ],
+            enums=[enum_b],
+        )
+
+        gen = PydanticGenerator()
+        with pytest.raises(ValueError, match="Enum name collision"):
+            gen.get_extra_files([schema_a, schema_b], Path("/tmp/out"))
+
     def test_no_enums_no_extra_file(self):
         """Schemas with no enums should not produce _enums.py."""
 


### PR DESCRIPTION
## Summary
- Raise `ValueError` when same-named enums have different members across schemas
- Previously the second definition was silently dropped (first-seen wins with no warning)
- Type `seen` dict as `dict[str, USREnum]` instead of `dict[str, Any]`

Follow-up to #45 (shared enum extraction). Found during code review.

## Test plan
- [x] New test: `test_name_collision_different_values_raises` — constructs two USRSchema objects with same-named enum but different values, asserts ValueError
- [x] All 7 shared enum tests pass
- [x] Pre-commit hooks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)