### PR TITLE
feat: add docs generator for human-readable Markdown schema documentation (#47)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -23,7 +23,7 @@ schema-gen init [OPTIONS]
 - `--input-dir TEXT` - Input directory for schemas (default: `schemas/`)
 - `--output-dir TEXT` - Output directory for generated files (default: `generated/`)
 - `--targets TEXT` - Comma-separated list of targets (default: `pydantic`)
-  Available targets: `pydantic`, `sqlalchemy`, `dataclasses`, `typeddict`, `pathway`, `zod`, `jsonschema`, `graphql`, `protobuf`, `avro`, `jackson`, `kotlin`
+  Available targets: `pydantic`, `sqlalchemy`, `dataclasses`, `typeddict`, `pathway`, `zod`, `jsonschema`, `graphql`, `protobuf`, `avro`, `jackson`, `kotlin`, `rust`, `docs`
 
 **Example:**
 ```bash

--- a/src/schema_gen/core/config.py
+++ b/src/schema_gen/core/config.py
@@ -39,6 +39,7 @@ class Config:
     jackson: dict[str, Any] = field(default_factory=dict)
     kotlin: dict[str, Any] = field(default_factory=dict)
     rust: dict[str, Any] = field(default_factory=dict)
+    docs: dict[str, Any] = field(default_factory=dict)
 
     # Generation settings
     overwrite: bool = True

--- a/src/schema_gen/generators/__init__.py
+++ b/src/schema_gen/generators/__init__.py
@@ -3,6 +3,7 @@
 from .avro_generator import AvroGenerator
 from .base import BaseGenerator
 from .dataclasses_generator import DataclassesGenerator
+from .docs_generator import DocsGenerator
 from .graphql_generator import GraphQLGenerator
 from .jackson_generator import JacksonGenerator
 from .jsonschema_generator import JsonSchemaGenerator
@@ -30,4 +31,5 @@ __all__ = [
     "JacksonGenerator",
     "KotlinGenerator",
     "RustGenerator",
+    "DocsGenerator",
 ]

--- a/src/schema_gen/generators/docs_generator.py
+++ b/src/schema_gen/generators/docs_generator.py
@@ -1,0 +1,241 @@
+"""Generator to create human-readable Markdown documentation from USR schemas."""
+
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from ..core.config import Config
+from ..core.usr import FieldType, USREnum, USRField, USRSchema
+from .base import BaseGenerator
+
+_DEFAULT_TITLE = "Schema Reference"
+
+
+class DocsGenerator(BaseGenerator):
+    """Generates Markdown documentation from USR schemas."""
+
+    def __init__(self, config: Config | None = None) -> None:
+        super().__init__(config=config)
+        self._docs_cfg: dict[str, Any] = (
+            getattr(config, "docs", None) or {} if config is not None else {}
+        )
+
+    @property
+    def file_extension(self) -> str:
+        return ".md"
+
+    @property
+    def generates_index_file(self) -> bool:
+        return True
+
+    index_filename: str = "index.md"
+
+    def get_schema_filename(self, schema: USRSchema) -> str:
+        return f"{schema.name.lower()}.md"
+
+    def generate_model(self, schema: USRSchema, variant: str | None = None) -> str:
+        return self.generate_file(schema)
+
+    def generate_file(self, schema: USRSchema) -> str:
+        lines: list[str] = []
+
+        # Title + description
+        lines.append(f"# {schema.name}")
+        lines.append("")
+        if schema.description:
+            lines.append(f"> {schema.description}")
+            lines.append("")
+
+        # Fields table
+        if schema.fields:
+            lines.append("## Fields")
+            lines.append("")
+            lines.append("| Field | Type | Required | Default | Description |")
+            lines.append("|-------|------|----------|---------|-------------|")
+            for field in schema.fields:
+                type_str = _render_type(field)
+                required = "yes" if _is_required(field) else "no"
+                default = _render_default(field)
+                desc = field.description or ""
+                lines.append(
+                    f"| {field.name} | {type_str} | {required} | {default} | {desc} |"
+                )
+            lines.append("")
+
+        # Enums section
+        if schema.enums:
+            lines.append("## Enums")
+            lines.append("")
+            for enum_def in schema.enums:
+                lines.append(f"### {enum_def.name}")
+                lines.append("")
+                lines.append("| Name | Value |")
+                lines.append("|------|-------|")
+                for member_name, member_value in enum_def.values:
+                    lines.append(f"| {member_name} | {member_value} |")
+                lines.append("")
+
+        # Variants section
+        if schema.variants:
+            lines.append("## Variants")
+            lines.append("")
+            for variant_name, variant_fields in schema.variants.items():
+                parts = variant_name.split("_")
+                variant_title = "".join(w.capitalize() for w in parts)
+                lines.append(f"### {schema.name}{variant_title}")
+                lines.append("")
+                lines.append(f"Fields: {', '.join(variant_fields)}")
+                lines.append("")
+
+        # Cross-references
+        nested_refs = _collect_nested_refs(schema)
+        if nested_refs:
+            lines.append("## Related Types")
+            lines.append("")
+            for ref_name in sorted(nested_refs):
+                lines.append(f"- [{ref_name}]({ref_name.lower()}.md)")
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def generate_index(self, schemas: list[USRSchema], output_dir: Path) -> str | None:
+        title = self._docs_cfg.get("title", _DEFAULT_TITLE)
+        lines: list[str] = []
+
+        lines.append(f"# {title}")
+        lines.append("")
+
+        # Schemas table
+        if schemas:
+            lines.append("## Schemas")
+            lines.append("")
+            lines.append("| Type | Description | Fields |")
+            lines.append("|------|-------------|--------|")
+            for schema in sorted(schemas, key=lambda s: s.name):
+                link = f"[{schema.name}]({schema.name.lower()}.md)"
+                desc = schema.description or ""
+                lines.append(f"| {link} | {desc} | {len(schema.fields)} |")
+            lines.append("")
+
+        # Enums table (de-duplicated across schemas)
+        all_enums: dict[str, tuple[USREnum, list[str]]] = {}
+        for schema in schemas:
+            for enum_def in schema.enums:
+                if enum_def.name not in all_enums:
+                    all_enums[enum_def.name] = (enum_def, [])
+                all_enums[enum_def.name][1].append(schema.name)
+
+        if all_enums:
+            lines.append("## Enums")
+            lines.append("")
+            lines.append("| Enum | Values | Used By |")
+            lines.append("|------|--------|---------|")
+            for enum_name in sorted(all_enums):
+                enum_def, used_by = all_enums[enum_name]
+                values = ", ".join(str(v) for _, v in enum_def.values)
+                if len(values) > 60:
+                    values = values[:57] + "..."
+                used_by_str = ", ".join(sorted(used_by))
+                lines.append(f"| {enum_name} | {values} | {used_by_str} |")
+            lines.append("")
+
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_TYPE_NAMES: dict[FieldType, str] = {
+    FieldType.STRING: "string",
+    FieldType.INTEGER: "integer",
+    FieldType.FLOAT: "float",
+    FieldType.BOOLEAN: "boolean",
+    FieldType.DATETIME: "datetime",
+    FieldType.DATE: "date",
+    FieldType.TIME: "time",
+    FieldType.UUID: "uuid",
+    FieldType.DECIMAL: "decimal",
+    FieldType.JSON: "json",
+    FieldType.BYTES: "bytes",
+}
+
+
+def _render_type(field: USRField) -> str:
+    """Render a human-readable type string for a field."""
+    if field.type == FieldType.ENUM:
+        return field.enum_name or "enum"
+    if field.type == FieldType.NESTED_SCHEMA:
+        name = field.nested_schema or "object"
+        return f"[{name}]({name.lower()}.md)"
+    if field.type == FieldType.LIST:
+        inner = _render_type(field.inner_type) if field.inner_type else "any"
+        return f"list[{inner}]"
+    if field.type in (FieldType.SET, FieldType.FROZENSET):
+        inner = _render_type(field.inner_type) if field.inner_type else "any"
+        return f"set[{inner}]"
+    if field.type == FieldType.DICT:
+        if field.inner_type:
+            val = _render_type(field.inner_type)
+            return f"dict[string, {val}]"
+        return "dict[string, any]"
+    if field.type == FieldType.UNION:
+        if field.union_types:
+            parts = [_render_type(ut) for ut in field.union_types]
+            return " | ".join(parts)
+        return "union"
+    if field.type == FieldType.OPTIONAL:
+        inner = _render_type(field.inner_type) if field.inner_type else "any"
+        return f"{inner} | null"
+    if field.type == FieldType.LITERAL:
+        if field.literal_values:
+            return "literal[" + ", ".join(repr(v) for v in field.literal_values) + "]"
+        return "literal"
+    if field.type == FieldType.TUPLE:
+        if field.union_types:
+            parts = [_render_type(ut) for ut in field.union_types]
+            return f"tuple[{', '.join(parts)}]"
+        return "tuple"
+    return _TYPE_NAMES.get(field.type, str(field.type.value).lower())
+
+
+def _is_required(field: USRField) -> bool:
+    """Return True if the field is required (no default, not optional)."""
+    return (
+        not field.optional and field.default is None and field.default_factory is None
+    )
+
+
+def _render_default(field: USRField) -> str:
+    """Render the default value for display."""
+    if field.default_factory is not None:
+        name = getattr(field.default_factory, "__name__", repr(field.default_factory))
+        return f"{name}()"
+    if field.default is None and field.optional:
+        return "None"
+    if field.default is None:
+        return "---"
+    if isinstance(field.default, Enum):
+        return f"{field.default.__class__.__name__}.{field.default.name}"
+    if isinstance(field.default, str):
+        return f'"{field.default}"'
+    return str(field.default)
+
+
+def _collect_nested_refs(schema: USRSchema) -> set[str]:
+    """Collect names of nested schema types referenced by this schema."""
+    refs: set[str] = set()
+    for field in schema.fields:
+        _collect_refs_from_field(field, refs)
+    return refs - {schema.name}  # Exclude self-references
+
+
+def _collect_refs_from_field(field: USRField, refs: set[str]) -> None:
+    if field.type == FieldType.NESTED_SCHEMA and field.nested_schema:
+        refs.add(field.nested_schema)
+    if field.inner_type:
+        _collect_refs_from_field(field.inner_type, refs)
+    if field.union_types:
+        for ut in field.union_types:
+            _collect_refs_from_field(ut, refs)

--- a/src/schema_gen/generators/registry.py
+++ b/src/schema_gen/generators/registry.py
@@ -2,6 +2,7 @@
 
 from .avro_generator import AvroGenerator
 from .dataclasses_generator import DataclassesGenerator
+from .docs_generator import DocsGenerator
 from .graphql_generator import GraphQLGenerator
 from .jackson_generator import JacksonGenerator
 from .jsonschema_generator import JsonSchemaGenerator
@@ -28,4 +29,5 @@ GENERATOR_REGISTRY: dict[str, type] = {
     "jackson": JacksonGenerator,
     "kotlin": KotlinGenerator,
     "rust": RustGenerator,
+    "docs": DocsGenerator,
 }

--- a/tests/test_docs_generator.py
+++ b/tests/test_docs_generator.py
@@ -1,0 +1,187 @@
+"""Tests for the Markdown docs generator."""
+
+from enum import Enum
+from pathlib import Path
+
+from schema_gen import Config, Field, Schema
+from schema_gen.core.schema import SchemaRegistry
+from schema_gen.generators.docs_generator import DocsGenerator
+from schema_gen.parsers.schema_parser import SchemaParser
+
+
+class _Status(str, Enum):
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+
+
+class TestDocsFieldTable:
+    def setup_method(self):
+        SchemaRegistry._schemas.clear()
+
+    def test_field_table_rendered(self):
+        @Schema
+        class User:
+            """A user account."""
+
+            name: str = Field(max_length=100, description="Full name")
+            age: int | None = Field(default=None, description="User age")
+
+        schema = SchemaParser().parse_schema(User)
+        md = DocsGenerator().generate_file(schema)
+
+        assert "# User" in md
+        assert "> A user account." in md
+        assert "| Field | Type | Required | Default | Description |" in md
+        assert "| name |" in md
+        assert "| yes |" in md  # name is required
+        assert "| age |" in md
+        assert "| no |" in md  # age is optional
+        assert "| None |" in md  # age default
+        assert "Full name" in md
+        assert "User age" in md
+
+
+class TestDocsEnumSection:
+    def setup_method(self):
+        SchemaRegistry._schemas.clear()
+
+    def test_enum_table_rendered(self):
+        @Schema
+        class Order:
+            status: _Status = Field(description="Current status")
+
+        schema = SchemaParser().parse_schema(Order)
+        md = DocsGenerator().generate_file(schema)
+
+        assert "## Enums" in md
+        assert "### _Status" in md
+        assert "| ACTIVE | active |" in md
+        assert "| INACTIVE | inactive |" in md
+
+
+class TestDocsVariants:
+    def setup_method(self):
+        SchemaRegistry._schemas.clear()
+
+    def test_variants_section(self):
+        @Schema
+        class Item:
+            id: int = Field(description="ID")
+            name: str = Field(description="Name")
+            price: float = Field(description="Price")
+
+            class Variants:
+                create_request = ["name", "price"]
+                public_response = ["id", "name"]
+
+        schema = SchemaParser().parse_schema(Item)
+        md = DocsGenerator().generate_file(schema)
+
+        assert "## Variants" in md
+        assert "### ItemCreateRequest" in md
+        assert "name, price" in md
+        assert "### ItemPublicResponse" in md
+        assert "id, name" in md
+
+
+class TestDocsCrossReferences:
+    def setup_method(self):
+        SchemaRegistry._schemas.clear()
+
+    def test_nested_type_linked(self):
+        @Schema
+        class Address:
+            street: str = Field(description="Street")
+
+        @Schema
+        class Person:
+            name: str = Field(description="Name")
+            address: Address = Field(description="Home address")
+
+        schema = SchemaParser().parse_schema(Person)
+        md = DocsGenerator().generate_file(schema)
+
+        assert "## Related Types" in md
+        assert "[Address](address.md)" in md
+        # Type column should also link
+        assert "[Address](address.md)" in md
+
+
+class TestDocsIndex:
+    def setup_method(self):
+        SchemaRegistry._schemas.clear()
+
+    def test_index_page(self):
+        @Schema
+        class Alpha:
+            """First schema."""
+
+            x: int = Field(description="x")
+
+        @Schema
+        class Beta:
+            """Second schema."""
+
+            y: str = Field(description="y")
+            status: _Status = Field(description="status")
+
+        schemas = SchemaParser().parse_all_schemas()
+        gen = DocsGenerator()
+        md = gen.generate_index(schemas, Path("/tmp"))
+
+        assert "# Schema Reference" in md
+        assert "## Schemas" in md
+        assert "[Alpha](alpha.md)" in md
+        assert "[Beta](beta.md)" in md
+        assert "First schema." in md
+        assert "## Enums" in md
+        assert "_Status" in md
+        assert "Beta" in md  # used by
+
+
+class TestDocsConfigTitle:
+    def setup_method(self):
+        SchemaRegistry._schemas.clear()
+
+    def test_custom_title(self):
+        @Schema
+        class Foo:
+            x: int = Field(description="x")
+
+        schemas = SchemaParser().parse_all_schemas()
+        config = Config(docs={"title": "TradingCore Contract Reference"})
+        gen = DocsGenerator(config=config)
+        md = gen.generate_index(schemas, Path("/tmp"))
+
+        assert "# TradingCore Contract Reference" in md
+
+
+class TestDocsRequiredVsOptional:
+    def setup_method(self):
+        SchemaRegistry._schemas.clear()
+
+    def test_required_and_optional_fields(self):
+        @Schema
+        class Mixed:
+            required_field: str = Field(description="must provide")
+            optional_field: int | None = Field(default=None, description="optional")
+            with_default: str = Field(default="hello", description="has default")
+            with_factory: list[str] = Field(
+                default_factory=list, description="factory default"
+            )
+
+        schema = SchemaParser().parse_schema(Mixed)
+        md = DocsGenerator().generate_file(schema)
+
+        lines = md.splitlines()
+        for line in lines:
+            if "| required_field |" in line:
+                assert "| yes |" in line
+            if "| optional_field |" in line:
+                assert "| no |" in line
+            if "| with_default |" in line:
+                assert "| no |" in line  # has default, not required
+                assert '"hello"' in line
+            if "| with_factory |" in line:
+                assert "| no |" in line
+                assert "list()" in line


### PR DESCRIPTION
## Summary

Adds `"docs"` as a generation target that produces browsable Markdown documentation from `@Schema` definitions.

**Per-schema page** (`generated/docs/{name}.md`):
- Field table with type, required/optional, default, description
- Enum tables with name/value pairs
- Variant listings showing included fields
- Cross-references linking to related schema types

**Index page** (`generated/docs/index.md`):
- Schema table with links, descriptions, field counts
- De-duplicated enum table showing which schemas use each enum

**Configuration** via `Config.docs`:
```python
config = Config(
    targets=["pydantic", "rust", "docs"],
    docs={"title": "TradingCore Contract Reference"},
)
```

Closes #47 (Phase 2 acceptance criteria)

## Test plan

- [x] 7 tests covering field tables, enums, variants, cross-refs, index, config, required/optional
- [x] All pre-commit hooks pass
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)