### PR TITLE
fix: remove UV_EXCLUDE_NEWER from CI — delay enforced at lockfile generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,9 @@ jobs:
         python-version: ["3.12"]
 
     steps:
-    - name: Set 7-day dependency delay
-      run: echo "UV_EXCLUDE_NEWER=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
+    # UV_EXCLUDE_NEWER is NOT set here. The 7-day supply chain delay is
+    # enforced at lockfile generation time (locally). CI uses --frozen
+    # installs from the committed lockfile — no resolution happens here.
 
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -101,8 +102,9 @@ jobs:
   schema-validation:
     runs-on: ubuntu-latest
     steps:
-    - name: Set 7-day dependency delay
-      run: echo "UV_EXCLUDE_NEWER=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
+    # UV_EXCLUDE_NEWER is NOT set here. The 7-day supply chain delay is
+    # enforced at lockfile generation time (locally). CI uses --frozen
+    # installs from the committed lockfile — no resolution happens here.
 
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -169,8 +171,9 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - name: Set 7-day dependency delay
-      run: echo "UV_EXCLUDE_NEWER=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
+    # UV_EXCLUDE_NEWER is NOT set here. The 7-day supply chain delay is
+    # enforced at lockfile generation time (locally). CI uses --frozen
+    # installs from the committed lockfile — no resolution happens here.
 
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/comprehensive-test.yml
+++ b/.github/workflows/comprehensive-test.yml
@@ -19,9 +19,6 @@ jobs:
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-    - name: Set 7-day dependency delay
-      run: echo "UV_EXCLUDE_NEWER=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
-
     - name: Install uv
       uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
       with:
@@ -139,9 +136,6 @@ jobs:
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-    - name: Set 7-day dependency delay
-      run: echo "UV_EXCLUDE_NEWER=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
-
     - name: Install uv
       uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
       with:
@@ -172,9 +166,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-    - name: Set 7-day dependency delay
-      run: echo "UV_EXCLUDE_NEWER=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
 
     - name: Install uv
       uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
@@ -245,9 +236,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-    - name: Set 7-day dependency delay
-      run: echo "UV_EXCLUDE_NEWER=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
 
     - name: Install uv
       uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,9 +29,6 @@ jobs:
       version: ${{ steps.version.outputs.version }}
 
     steps:
-    - name: Set 7-day dependency delay
-      run: echo "UV_EXCLUDE_NEWER=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
-
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0  # Full history for version detection

--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -11,9 +11,6 @@ jobs:
   check-generated-schemas:
     runs-on: ubuntu-latest
     steps:
-    - name: Set 7-day dependency delay
-      run: echo "UV_EXCLUDE_NEWER=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
-
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 2  # Need to compare with previous commit

--- a/.github/workflows/version-compatibility.yml
+++ b/.github/workflows/version-compatibility.yml
@@ -23,9 +23,6 @@ jobs:
       fail-fast: false
 
     steps:
-    - name: Set 7-day dependency delay
-      run: echo "UV_EXCLUDE_NEWER=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
-
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Install uv


### PR DESCRIPTION
## Summary

Root cause of all CI failures: `UV_EXCLUDE_NEWER` was set in CI workflows, causing `uv run` to re-resolve against a different timestamp than what's baked into `uv.lock`. This broke `--frozen` installs and caused "Failed to spawn: ruff" errors.

**Fix:** Remove `UV_EXCLUDE_NEWER` from all CI jobs. The 7-day supply chain delay is enforced at lockfile generation time (locally via `~/.bashrc`) and baked into `uv.lock`. CI uses `--frozen` installs which read from the committed lockfile without resolution.

This matches the correct pattern: delay at resolution time (local dev), frozen at install time (CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)