### PR TITLE
fix: add --frozen to all uv run commands in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,42 +57,42 @@ jobs:
 
     - name: Run linting
       run: |
-        uv run ruff check src/ tests/
-        uv run ruff format --check src/ tests/
+        uv run --frozen ruff check src/ tests/
+        uv run --frozen ruff format --check src/ tests/
 
     - name: Run tests
-      run: uv run pytest tests/ -v --cov=src/schema_gen --cov-report=xml
+      run: uv run --frozen pytest tests/ -v --cov=src/schema_gen --cov-report=xml
 
     - name: Run version compatibility tests
       run: |
         # Run basic compatibility tests with current versions
-        uv run pytest tests/test_version_compatibility.py::TestVersionCompatibility::test_current_pydantic_version_compatibility -v
-        uv run pytest tests/test_version_compatibility.py::TestVersionCompatibility::test_generated_code_syntax_validation -v
-        uv run pytest tests/test_version_compatibility.py::TestVersionRequirements::test_minimum_version_requirements -v
+        uv run --frozen pytest tests/test_version_compatibility.py::TestVersionCompatibility::test_current_pydantic_version_compatibility -v
+        uv run --frozen pytest tests/test_version_compatibility.py::TestVersionCompatibility::test_generated_code_syntax_validation -v
+        uv run --frozen pytest tests/test_version_compatibility.py::TestVersionRequirements::test_minimum_version_requirements -v
 
         # Test all generators compatibility
-        uv run pytest tests/test_version_compatibility.py::TestAllGeneratorCompatibility::test_all_python_generators -v
-        uv run pytest tests/test_version_compatibility.py::TestAllGeneratorCompatibility::test_all_schema_generators -v
-        uv run pytest tests/test_version_compatibility.py::TestAllGeneratorCompatibility::test_all_language_generators -v
+        uv run --frozen pytest tests/test_version_compatibility.py::TestAllGeneratorCompatibility::test_all_python_generators -v
+        uv run --frozen pytest tests/test_version_compatibility.py::TestAllGeneratorCompatibility::test_all_schema_generators -v
+        uv run --frozen pytest tests/test_version_compatibility.py::TestAllGeneratorCompatibility::test_all_language_generators -v
 
         # Test schema library compatibility (if installed)
-        uv run pytest tests/test_version_compatibility.py::TestVersionCompatibility::test_current_jsonschema_version_compatibility -v || echo "jsonschema not installed"
-        uv run pytest tests/test_version_compatibility.py::TestVersionCompatibility::test_current_graphql_version_compatibility -v || echo "graphql-core not installed"
+        uv run --frozen pytest tests/test_version_compatibility.py::TestVersionCompatibility::test_current_jsonschema_version_compatibility -v || echo "jsonschema not installed"
+        uv run --frozen pytest tests/test_version_compatibility.py::TestVersionCompatibility::test_current_graphql_version_compatibility -v || echo "graphql-core not installed"
 
     - name: Test CLI functionality
       run: |
         # Test basic CLI commands
-        uv run schema-gen --help
+        uv run --frozen schema-gen --help
 
         # Test project initialization
         mkdir test_project && cd test_project
-        uv run schema-gen init
+        uv run --frozen schema-gen init
 
         # Test generation
-        uv run schema-gen generate
+        uv run --frozen schema-gen generate
 
         # Test validation
-        uv run schema-gen validate
+        uv run --frozen schema-gen validate
 
         # Verify generated files exist
         ls -la generated/pydantic/
@@ -152,13 +152,13 @@ jobs:
         EOF
 
         # Generate schemas
-        uv run schema-gen generate
+        uv run --frozen schema-gen generate
 
         # Validate schemas are up-to-date
-        uv run schema-gen validate
+        uv run --frozen schema-gen validate
 
         # Verify generated content is valid Python
-        uv run python -c "
+        uv run --frozen python -c "
         import sys
         sys.path.append('test_generated/pydantic')
         from testmodel_models import TestModel, TestModelCreate, TestModelResponse
@@ -166,7 +166,7 @@ jobs:
         "
 
         # Test all generators using the compatibility checker
-        uv run python scripts/check_compatibility.py --library all-generators
+        uv run --frozen python scripts/check_compatibility.py --library all-generators
 
   docs:
     runs-on: ubuntu-latest
@@ -191,7 +191,7 @@ jobs:
       run: uv sync --frozen --group dev
 
     - name: Build documentation
-      run: uv run mkdocs build --strict
+      run: uv run --frozen mkdocs build --strict
 
     - name: Test documentation links
-      run: uv run mkdocs build --strict --verbose
+      run: uv run --frozen mkdocs build --strict --verbose

--- a/.github/workflows/comprehensive-test.yml
+++ b/.github/workflows/comprehensive-test.yml
@@ -35,14 +35,14 @@ jobs:
     - name: Run quick format validation
       run: |
         # Python syntax validation (fast)
-        uv run pytest tests/test_format_validation.py::TestFormatValidation -v
+        uv run --frozen pytest tests/test_format_validation.py::TestFormatValidation -v
 
         # Comprehensive format validation (no external compilers)
-        uv run python scripts/validate_all_formats.py --verbose
+        uv run --frozen python scripts/validate_all_formats.py --verbose
 
     - name: Run unit tests with coverage
       run: |
-        uv run pytest tests/ -v --cov=src/schema_gen --cov-report=xml --cov-report=term
+        uv run --frozen pytest tests/ -v --cov=src/schema_gen --cov-report=xml --cov-report=term
 
     - name: Upload coverage to Codecov
       if: success()
@@ -108,19 +108,19 @@ jobs:
 
           # Test TypeScript/Zod compilation
           echo 'Testing TypeScript compilation...'
-          uv run python scripts/validate_all_formats.py --format zod --verbose
+          uv run --frozen python scripts/validate_all_formats.py --format zod --verbose
 
           # Test Java/Jackson compilation
           echo 'Testing Java compilation...'
-          uv run python scripts/validate_all_formats.py --format jackson --verbose
+          uv run --frozen python scripts/validate_all_formats.py --format jackson --verbose
 
           # Test Kotlin compilation
           echo 'Testing Kotlin compilation...'
-          uv run python scripts/validate_all_formats.py --format kotlin --verbose
+          uv run --frozen python scripts/validate_all_formats.py --format kotlin --verbose
 
           # Test Protocol Buffers compilation
           echo 'Testing Protocol Buffers compilation...'
-          uv run python scripts/validate_all_formats.py --format protobuf --verbose
+          uv run --frozen python scripts/validate_all_formats.py --format protobuf --verbose
         "
 
   # Test across different Python versions
@@ -153,10 +153,10 @@ jobs:
     - name: Test format validation on Python ${{ matrix.python-version }}
       run: |
         # Run format validation tests
-        uv run pytest tests/test_format_validation.py -v
+        uv run --frozen pytest tests/test_format_validation.py -v
 
         # Test Python code generation and execution
-        uv run pytest tests/test_format_validation.py::TestGeneratedCodeExecution -v
+        uv run --frozen pytest tests/test_format_validation.py::TestGeneratedCodeExecution -v
 
   # Performance and stress testing
   performance-validation:
@@ -210,14 +210,14 @@ jobs:
 
         # Time the generation process
         echo "Testing generation performance..."
-        time uv run schema-gen generate \
+        time uv run --frozen schema-gen generate \
           --input perf_test/schemas \
           --output perf_test/generated \
           --target pydantic
 
         # Validate generated files
         echo "Validating large generated files..."
-        uv run python -c "
+        uv run --frozen python -c "
         import sys
         sys.path.append('perf_test/generated/pydantic')
         import largetestschema_models
@@ -253,14 +253,14 @@ jobs:
     - name: Test core functionality on ${{ matrix.os }}
       run: |
         # Basic CLI functionality
-        uv run schema-gen --version
-        uv run schema-gen --help
+        uv run --frozen schema-gen --version
+        uv run --frozen schema-gen --help
 
         # Format validation (no external compilers on Windows/Mac)
-        uv run pytest tests/test_format_validation.py::TestFormatValidation -v
+        uv run --frozen pytest tests/test_format_validation.py::TestFormatValidation -v
 
         # Python code generation and execution
-        uv run pytest tests/test_format_validation.py::TestGeneratedCodeExecution -v
+        uv run --frozen pytest tests/test_format_validation.py::TestGeneratedCodeExecution -v
 
   # Summary job that depends on all validation jobs
   validation-summary:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,16 +66,16 @@ jobs:
     - name: Run comprehensive tests
       run: |
         # Run full test suite with coverage
-        uv run pytest tests/ -v --cov=src/schema_gen --cov-report=xml --cov-fail-under=65
+        uv run --frozen pytest tests/ -v --cov=src/schema_gen --cov-report=xml --cov-fail-under=65
 
         # Run format validation tests (syntax and execution validation)
-        uv run pytest tests/test_format_validation.py -v
+        uv run --frozen pytest tests/test_format_validation.py -v
 
         # Test all generators
-        uv run python scripts/check_compatibility.py --library all-generators
+        uv run --frozen python scripts/check_compatibility.py --library all-generators
 
         # Comprehensive format validation with external tool validation
-        uv run python scripts/validate_all_formats.py --verbose
+        uv run --frozen python scripts/validate_all_formats.py --verbose
 
     - name: Run Docker-based comprehensive validation
       run: |
@@ -91,24 +91,24 @@ jobs:
 
     - name: Run linting and type checking
       run: |
-        uv run ruff check src/ tests/
-        uv run ruff format --check src/ tests/
+        uv run --frozen ruff check src/ tests/
+        uv run --frozen ruff format --check src/ tests/
 
     - name: Test CLI functionality
       run: |
         # Test basic CLI commands
-        uv run schema-gen --help
-        uv run schema-gen --version
+        uv run --frozen schema-gen --help
+        uv run --frozen schema-gen --version
 
         # Test project initialization in clean directory
         mkdir test_project && cd test_project
-        uv run schema-gen init
+        uv run --frozen schema-gen init
 
         # Test generation with created schemas
-        uv run schema-gen generate --verbose
+        uv run --frozen schema-gen generate --verbose
 
         # Test validation
-        uv run schema-gen validate
+        uv run --frozen schema-gen validate
 
         # Verify generated files exist and are valid Python
         test -f generated/pydantic/user_models.py
@@ -122,8 +122,8 @@ jobs:
         ls -la dist/
 
         # Show package contents
-        uv run pip install twine
-        uv run python -m twine check dist/* --strict
+        uv run --frozen pip install twine
+        uv run --frozen python -m twine check dist/* --strict
 
     - name: Verify package installation
       run: |

--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -44,7 +44,7 @@ jobs:
         rm -rf generated/
 
         # Generate fresh schemas
-        uv run schema-gen generate
+        uv run --frozen schema-gen generate
 
         # Check if there are any differences
         if git diff --quiet generated/; then
@@ -60,10 +60,10 @@ jobs:
       if: steps.check_schemas.outputs.schemas_exist == 'true'
       run: |
         # Validate that all schema files are syntactically correct
-        find schemas/ -name "*.py" -exec uv run python -m py_compile {} \;
+        find schemas/ -name "*.py" -exec uv run --frozen python -m py_compile {} \;
 
         # Try to import and validate each schema
-        uv run python -c "
+        uv run --frozen python -c "
         import sys
         import os
         from pathlib import Path
@@ -103,7 +103,7 @@ jobs:
       if: steps.check_schemas.outputs.schemas_exist == 'true'
       run: |
         # Test that generated models can be imported and used
-        uv run python -c "
+        uv run --frozen python -c "
         import sys
         from pathlib import Path
 

--- a/.github/workflows/version-compatibility.yml
+++ b/.github/workflows/version-compatibility.yml
@@ -41,16 +41,16 @@ jobs:
     - name: Test all generators compatibility
       run: |
         # Test all generators with currently installed versions
-        uv run python scripts/check_compatibility.py --library all-generators
+        uv run --frozen python scripts/check_compatibility.py --library all-generators
 
     - name: Run version compatibility test suite
       run: |
         # Run the comprehensive compatibility test suite
-        uv run pytest tests/test_version_compatibility.py -v
+        uv run --frozen pytest tests/test_version_compatibility.py -v
 
     - name: Validate version matrix configuration
       run: |
-        uv run python -c "
+        uv run --frozen python -c "
         import yaml
         with open('tests/test-matrix.yml', 'r') as f:
             matrix = yaml.safe_load(f)


### PR DESCRIPTION
## Summary

`uv run` without `--frozen` re-resolves dependencies against pyproject.toml, which installs a different (minimal) set of packages than what `uv sync --frozen --all-extras --dev` installed. This caused `ruff` and other dev tools to be missing.

Adding `--frozen` to all `uv run` commands ensures they use the already-installed venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)