### PR TITLE
fix: use .python-version for CI Python setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: lockfile-check
-    strategy:
-      matrix:
-        python-version: ["3.12"]
-
     steps:
     # UV_EXCLUDE_NEWER is NOT set here. The 7-day supply chain delay is
     # enforced at lockfile generation time (locally). CI uses --frozen
@@ -49,11 +45,11 @@ jobs:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
 
-    - name: Set up Python ${{ matrix.python-version }}
-      run: uv python install ${{ matrix.python-version }}
+    - name: Set up Python
+      run: uv python install
 
     - name: Install dependencies
-      run: uv sync --frozen --all-extras --dev --python ${{ matrix.python-version }}
+      run: uv sync --frozen --all-extras --dev
 
     - name: Run linting
       run: |
@@ -116,7 +112,7 @@ jobs:
         cache-dependency-glob: "uv.lock"
 
     - name: Set up Python
-      run: uv python install 3.12
+      run: uv python install
 
     - name: Install dependencies
       run: uv sync --frozen
@@ -185,7 +181,7 @@ jobs:
         cache-dependency-glob: "uv.lock"
 
     - name: Set up Python
-      run: uv python install 3.12
+      run: uv python install
 
     - name: Install dependencies
       run: uv sync --frozen --group dev


### PR DESCRIPTION
## Summary

`uv python install 3.12` installed 3.12.13 while `.python-version` pins 3.12.10. This mismatch caused `uv sync --frozen` to recreate the venv, losing dev tools. `uv run --frozen ruff` then failed with "Failed to spawn: ruff".

Fix: Use `uv python install` (reads `.python-version`) instead of `uv python install 3.12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)