### PR TITLE
fix: SQLAlchemy String import and FastAPI variant in version compat tests

### DIFF
--- a/src/schema_gen/generators/sqlalchemy_generator.py
+++ b/src/schema_gen/generators/sqlalchemy_generator.py
@@ -239,6 +239,7 @@ class SqlAlchemyGenerator(BaseGenerator):
 
         if field.type == FieldType.STRING:
             if field.max_length:
+                imports.add("sqlalchemy.String")
                 return f"String({field.max_length})", "str"
             else:
                 imports.add("sqlalchemy.Text")
@@ -281,6 +282,7 @@ class SqlAlchemyGenerator(BaseGenerator):
 
         elif field.type == FieldType.ENUM:
             # Use String with length based on max enum value length
+            imports.add("sqlalchemy.String")
             if field.enum_values:
                 max_len = max(len(str(v)) for v in field.enum_values)
                 return f"String({max(max_len, 20)})", "str"
@@ -288,6 +290,7 @@ class SqlAlchemyGenerator(BaseGenerator):
 
         else:
             # Default to String for unknown types
+            imports.add("sqlalchemy.String")
             return "String(255)", "str"
 
     def _variant_to_class_name(self, schema_name: str, variant_name: str) -> str:

--- a/tests/test_rust_generator.py
+++ b/tests/test_rust_generator.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-import pytest
 from datetime import datetime
 from decimal import Decimal
 from enum import Enum, StrEnum
 from pathlib import Path
 from typing import Any
 from uuid import UUID
+
+import pytest
 
 from schema_gen import Field, Schema
 from schema_gen.core.schema import SchemaRegistry

--- a/tests/test_version_compatibility.py
+++ b/tests/test_version_compatibility.py
@@ -529,7 +529,7 @@ Base = declarative_base()
 
         # Test that generated Pydantic models work with FastAPI
         pydantic_gen = PydanticGenerator()
-        pydantic_code = pydantic_gen.generate_model(test_schema)
+        pydantic_code = pydantic_gen.generate_file(test_schema)
 
         # This would test actual usage in a FastAPI app
         self._test_fastapi_integration(pydantic_code)


### PR DESCRIPTION
## Summary

Two test fixes:

1. **SQLAlchemy**: Generator used `String(N)` without importing `sqlalchemy.String`. Added the import in all code paths that produce `String(...)` expressions.

2. **FastAPI**: Test called `generate_model()` (base class only) instead of `generate_file()` (base + variants). The FastAPI integration expected variant classes (`UserCreate`, `UserResponse`) which are only produced by `generate_file()`.

## Test plan

- [x] `test_current_sqlalchemy_version_compatibility` passes
- [x] `test_end_to_end_version_compatibility` passes
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)