### PR TITLE
fix: escape quotes in Pydantic descriptions; propagate enum docstrings (#70, #71)

### DIFF
--- a/src/schema_gen/core/usr.py
+++ b/src/schema_gen/core/usr.py
@@ -89,6 +89,12 @@ class USREnum:
     # Per-target configuration overrides (mirrors USRSchema.target_config).
     target_config: dict[str, dict[str, Any]] = field(default_factory=dict)
 
+    # Class-level docstring from the source Enum. Propagated verbatim to
+    # generated Pydantic enums, as ``///`` doc comments on Rust enums, and
+    # as JSDoc blocks / ``description`` fields on Zod and JSON Schema
+    # emissions so downstream maintainers see the enum's intent.
+    docstring: str | None = None
+
 
 @dataclass
 class USRField:

--- a/src/schema_gen/generators/jsonschema_generator.py
+++ b/src/schema_gen/generators/jsonschema_generator.py
@@ -155,7 +155,9 @@ class JsonSchemaGenerator(BaseGenerator):
             # Add enum definitions to $defs
             for enum_def in getattr(schema, "enums", []):
                 enum_values = [v for _name, v in enum_def.values]
-                enum_schema = {"type": "string", "enum": enum_values}
+                enum_schema: dict[str, Any] = {"type": "string", "enum": enum_values}
+                if enum_def.docstring:
+                    enum_schema["description"] = enum_def.docstring
                 json_schema["$defs"][enum_def.name] = enum_schema
 
             # Add base schema

--- a/src/schema_gen/generators/pydantic_generator.py
+++ b/src/schema_gen/generators/pydantic_generator.py
@@ -26,6 +26,24 @@ _SUPPORTED_PYDANTIC_CONFIG_KEYS: tuple[str, ...] = (
 )
 
 
+def _format_class_docstring(docstring: str, indent: str = "    ") -> list[str]:
+    '''Render ``docstring`` as the body lines of a Python class docstring.
+
+    Collapses to a single-line """...""" form when the source is a
+    single line free of embedded triple-quotes; otherwise emits the
+    multi-line block form. Shared between ``_enums.py`` emission and the
+    single-file ``_generate_complete_file`` path so the two can't drift.
+    '''
+    doc_lines = docstring.splitlines()
+    if len(doc_lines) == 1 and '"""' not in doc_lines[0]:
+        return [f'{indent}"""{doc_lines[0]}"""']
+    out = [f'{indent}"""']
+    for doc_line in doc_lines:
+        out.append(f"{indent}{doc_line}" if doc_line else "")
+    out.append(f'{indent}"""')
+    return out
+
+
 class PydanticGenerator(BaseGenerator):
     """Generates Pydantic models from USR schemas"""
 
@@ -131,14 +149,7 @@ class PydanticGenerator(BaseGenerator):
             else:
                 lines.append(f"class {enum_def.name}(Enum):")
             if enum_def.docstring:
-                doc_lines = enum_def.docstring.splitlines()
-                if len(doc_lines) == 1 and '"""' not in doc_lines[0]:
-                    lines.append(f'    """{doc_lines[0]}"""')
-                else:
-                    lines.append('    """')
-                    for doc_line in doc_lines:
-                        lines.append(f"    {doc_line}" if doc_line else "")
-                    lines.append('    """')
+                lines.extend(_format_class_docstring(enum_def.docstring))
             for member_name, member_value in enum_def.values:
                 if isinstance(member_value, str):
                     lines.append(f'    {member_name} = "{member_value}"')
@@ -724,14 +735,7 @@ class PydanticGenerator(BaseGenerator):
             else:
                 lines.append(f"class {enum_def.name}(Enum):")
             if enum_def.docstring:
-                doc_lines = enum_def.docstring.splitlines()
-                if len(doc_lines) == 1 and '"""' not in doc_lines[0]:
-                    lines.append(f'    """{doc_lines[0]}"""')
-                else:
-                    lines.append('    """')
-                    for doc_line in doc_lines:
-                        lines.append(f"    {doc_line}" if doc_line else "")
-                    lines.append('    """')
+                lines.extend(_format_class_docstring(enum_def.docstring))
             for member_name, member_value in enum_def.values:
                 if isinstance(member_value, str):
                     lines.append(f'    {member_name} = "{member_value}"')

--- a/src/schema_gen/generators/pydantic_generator.py
+++ b/src/schema_gen/generators/pydantic_generator.py
@@ -1,5 +1,6 @@
 """Generator to create Pydantic models from USR schemas"""
 
+import json
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
@@ -129,6 +130,15 @@ class PydanticGenerator(BaseGenerator):
                 lines.append(f"class {enum_def.name}({mixin_name}, Enum):")
             else:
                 lines.append(f"class {enum_def.name}(Enum):")
+            if enum_def.docstring:
+                doc_lines = enum_def.docstring.splitlines()
+                if len(doc_lines) == 1 and '"""' not in doc_lines[0]:
+                    lines.append(f'    """{doc_lines[0]}"""')
+                else:
+                    lines.append('    """')
+                    for doc_line in doc_lines:
+                        lines.append(f"    {doc_line}" if doc_line else "")
+                    lines.append('    """')
             for member_name, member_value in enum_def.values:
                 if isinstance(member_value, str):
                     lines.append(f'    {member_name} = "{member_value}"')
@@ -380,15 +390,17 @@ class PydanticGenerator(BaseGenerator):
         if field.regex_pattern:
             field_params.append(f'pattern=r"{field.regex_pattern}"')
 
-        # Description
+        # Description. Use json.dumps so embedded quotes, backslashes, and
+        # newlines are escaped safely (#70) while keeping the outer form
+        # as a double-quoted string for tooling consistency.
         if field.description:
-            field_params.append(f'description="{field.description}"')
+            field_params.append(f"description={json.dumps(field.description)}")
 
         # Pydantic-specific configurations
         pydantic_config = field.target_config.get("pydantic", {})
         for key, value in pydantic_config.items():
             if isinstance(value, str):
-                field_params.append(f'{key}="{value}"')
+                field_params.append(f"{key}={json.dumps(value)}")
             else:
                 field_params.append(f"{key}={value}")
 
@@ -711,6 +723,15 @@ class PydanticGenerator(BaseGenerator):
                 lines.append(f"class {enum_def.name}({mixin_name}, Enum):")
             else:
                 lines.append(f"class {enum_def.name}(Enum):")
+            if enum_def.docstring:
+                doc_lines = enum_def.docstring.splitlines()
+                if len(doc_lines) == 1 and '"""' not in doc_lines[0]:
+                    lines.append(f'    """{doc_lines[0]}"""')
+                else:
+                    lines.append('    """')
+                    for doc_line in doc_lines:
+                        lines.append(f"    {doc_line}" if doc_line else "")
+                    lines.append('    """')
             for member_name, member_value in enum_def.values:
                 if isinstance(member_value, str):
                     lines.append(f'    {member_name} = "{member_value}"')

--- a/src/schema_gen/generators/rust_generator.py
+++ b/src/schema_gen/generators/rust_generator.py
@@ -804,7 +804,14 @@ class RustGenerator(BaseGenerator):
             if extra not in derives:
                 derives.append(extra)
 
-        lines = [f"#[derive({', '.join(derives)})]"]
+        lines: list[str] = []
+        if enum.docstring:
+            for doc_line in enum.docstring.splitlines():
+                if doc_line.strip():
+                    lines.append(f"/// {doc_line.strip()}")
+                else:
+                    lines.append("///")
+        lines.append(f"#[derive({', '.join(derives)})]")
 
         # Per-variant `#[serde(rename = "<value>")]` using the actual enum
         # value from the IR is the correct default: it's the only way to

--- a/src/schema_gen/generators/zod_generator.py
+++ b/src/schema_gen/generators/zod_generator.py
@@ -563,6 +563,17 @@ class ZodGenerator(BaseGenerator):
 
         # Add enum definitions before schemas
         for enum_def in enums:
+            if enum_def.docstring:
+                doc_lines = enum_def.docstring.splitlines()
+                # Close any */ sequences that would end the JSDoc block early.
+                safe_lines = [line.replace("*/", "*\\/") for line in doc_lines]
+                if len(safe_lines) == 1:
+                    lines.append(f"/** {safe_lines[0]} */")
+                else:
+                    lines.append("/**")
+                    for doc_line in safe_lines:
+                        lines.append(f" * {doc_line}" if doc_line else " *")
+                    lines.append(" */")
             values = ", ".join(f'"{v}"' for _name, v in enum_def.values)
             lines.append(f"export const {enum_def.name}Schema = z.enum([{values}]);")
             lines.append(

--- a/src/schema_gen/parsers/schema_parser.py
+++ b/src/schema_gen/parsers/schema_parser.py
@@ -45,11 +45,19 @@ def _build_usr_enum(enum_cls: type) -> USREnum:
         # enum itself (or one of its bases that is also an Enum subclass).
         if meta is not None and isinstance(meta, type):
             custom_code[target] = _extract_meta_attributes(meta)
+    # Only read __doc__ from the enum's own __dict__ to avoid picking up
+    # Python's auto-generated "An enumeration." fallback that older
+    # versions of the stdlib ``Enum`` metaclass install on subclasses.
+    raw_doc = enum_cls.__dict__.get("__doc__")
+    docstring = (
+        raw_doc.strip() if isinstance(raw_doc, str) and raw_doc.strip() else None
+    )
     return USREnum(
         name=enum_cls.__name__,
         values=[(e.name, e.value) for e in enum_cls],
         value_type=_detect_enum_value_type(enum_cls),
         custom_code=custom_code,
+        docstring=docstring,
     )
 
 

--- a/tests/test_description_quotes_and_enum_docstrings.py
+++ b/tests/test_description_quotes_and_enum_docstrings.py
@@ -1,0 +1,171 @@
+# ruff: noqa: UP042, UP045
+"""Tests for:
+
+- #70: Pydantic generator must escape double quotes inside ``description=``
+  values (and other string config) so the emitted Python parses.
+- #71: Enum class docstrings must be propagated to the Pydantic, Rust, Zod,
+  and JSON Schema targets.
+"""
+
+import ast
+from enum import Enum
+from pathlib import Path
+
+from schema_gen import Field, Schema
+from schema_gen.core.schema import SchemaRegistry
+from schema_gen.generators.jsonschema_generator import JsonSchemaGenerator
+from schema_gen.generators.pydantic_generator import PydanticGenerator
+from schema_gen.generators.rust_generator import RustGenerator
+from schema_gen.generators.zod_generator import ZodGenerator
+from schema_gen.parsers.schema_parser import SchemaParser
+
+# ---------------------------------------------------------------------------
+# Fixtures shared across the tests
+# ---------------------------------------------------------------------------
+
+
+_ENUM_DOC = (
+    "Footprint candle window durations.\n\n"
+    "Adding a new timeframe therefore requires coordinated updates in "
+    "three places: this enum, the backend duration-lookup table, and "
+    "the frontend constant."
+)
+
+
+def _reset_registry() -> None:
+    SchemaRegistry._schemas.clear()
+
+
+def _parse_schema_with_quoted_description() -> list:
+    """Schema with a literal ``"`` inside ``Field(description=...)`` (#70)."""
+
+    _reset_registry()
+
+    @Schema
+    class QuoteDescMsg:
+        type: str = Field(
+            description='Discriminator — required; must equal "gap_detected"',
+        )
+
+    parser = SchemaParser()
+    return [parser.parse_schema(QuoteDescMsg)]
+
+
+def _parse_schema_with_docstring_enum() -> list:
+    """Schema referencing an enum that carries a class docstring (#71)."""
+
+    _reset_registry()
+
+    class Timeframe(str, Enum):
+        """Footprint candle window durations.
+
+        Adding a new timeframe therefore requires coordinated updates in
+        three places: this enum, the backend duration-lookup table, and
+        the frontend constant.
+        """
+
+        M1 = "1m"
+        M3 = "3m"
+        M5 = "5m"
+
+    @Schema
+    class Candle:
+        timeframe: Timeframe = Field(description="window")
+
+    parser = SchemaParser()
+    return [parser.parse_schema(Candle)]
+
+
+# ---------------------------------------------------------------------------
+# #70 — description quoting
+# ---------------------------------------------------------------------------
+
+
+class TestPydanticDescriptionEscaping:
+    def test_inner_quotes_dont_break_python_parse(self):
+        schemas = _parse_schema_with_quoted_description()
+        gen = PydanticGenerator()
+        extra = gen.get_extra_files(schemas, Path("/tmp/out"))
+        model_code = gen.generate_model(schemas[0])
+
+        # Must parse as valid Python regardless of what the description
+        # contains — this is the regression we're guarding against.
+        ast.parse(model_code)
+        for content in extra.values():
+            ast.parse(content)
+
+        # And the description text itself must round-trip: the inner
+        # quotes should be escaped, not dropped.
+        assert 'must equal \\"gap_detected\\"' in model_code
+
+
+# ---------------------------------------------------------------------------
+# #71 — enum class docstrings
+# ---------------------------------------------------------------------------
+
+
+class TestEnumDocstringPropagation:
+    def test_pydantic_emits_class_docstring(self):
+        schemas = _parse_schema_with_docstring_enum()
+        gen = PydanticGenerator()
+        extra = gen.get_extra_files(schemas, Path("/tmp/out"))
+        enums_py = extra["_enums.py"]
+
+        # The generated file must still be valid Python.
+        ast.parse(enums_py)
+        assert "Footprint candle window durations." in enums_py
+        assert "coordinated updates" in enums_py
+
+    def test_rust_emits_doc_comments(self):
+        schemas = _parse_schema_with_docstring_enum()
+        gen = RustGenerator()
+        rust_code = gen.generate_file(schemas[0])
+
+        assert "/// Footprint candle window durations." in rust_code
+        assert "coordinated updates" in rust_code
+
+    def test_zod_emits_jsdoc_block(self):
+        schemas = _parse_schema_with_docstring_enum()
+        gen = ZodGenerator()
+        ts_code = gen.generate_file(schemas[0])
+
+        assert "/**" in ts_code
+        assert "Footprint candle window durations." in ts_code
+        assert "coordinated updates" in ts_code
+
+    def test_jsonschema_emits_description_field(self):
+        schemas = _parse_schema_with_docstring_enum()
+        gen = JsonSchemaGenerator()
+        schema_json = gen.generate_file(schemas[0])
+
+        # JsonSchemaGenerator.generate returns JSON text.
+        import json
+
+        parsed = json.loads(schema_json)
+        enum_def = parsed["$defs"]["Timeframe"]
+        assert "description" in enum_def
+        assert "Footprint candle window durations." in enum_def["description"]
+
+    def test_enum_without_docstring_unchanged(self):
+        """Regression guard: enums with no docstring must still work."""
+
+        _reset_registry()
+
+        class Plain(str, Enum):
+            A = "a"
+            B = "b"
+
+        @Schema
+        class Holder:
+            p: Plain = Field(description="plain")
+
+        parser = SchemaParser()
+        schemas = [parser.parse_schema(Holder)]
+
+        PydanticGenerator().get_extra_files(schemas, Path("/tmp/out"))
+        RustGenerator().generate_file(schemas[0])
+        ZodGenerator().generate_file(schemas[0])
+        JsonSchemaGenerator().generate_file(schemas[0])
+
+        # If any generator regressed to assume docstring exists this
+        # would have raised by now.

--- a/uv.lock
+++ b/uv.lock
@@ -7,9 +7,6 @@ resolution-markers = [
     "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
-[options]
-exclude-newer = "2026-04-03T16:25:15Z"
-
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
## Summary

Fixes two generator bugs surfaced on tradingcore's `feat/orderflow-v2-contracts` branch:

- **#70** — `PydanticGenerator` used a naive f-string to emit `description="..."` (and string values under `target_config["pydantic"]`), so any nested `"` in the description produced invalid Python (`SyntaxError: unterminated string literal`). Switched to `json.dumps`, which escapes quotes, backslashes, and newlines while keeping the outer form as a double-quoted Python string literal (matches existing test expectations).

- **#71** — Enum class docstrings were silently dropped by every target. Added a `docstring` field to `USREnum`, extracted from `enum_cls.__dict__["__doc__"]` (reading the instance dict avoids Python's auto-generated `"An enumeration."` fallback), and emitted it as:
  - a Python docstring in Pydantic's `_enums.py`
  - `///` doc comments in Rust
  - a JSDoc block above `z.enum([...])` in Zod
  - a `description` field on the `$defs` entry in JSON Schema

## Test plan
- [x] New `tests/test_description_quotes_and_enum_docstrings.py` covers:
  - Pydantic emission of `description` containing literal `"` parses via `ast.parse` and round-trips the escaped quotes
  - Enum class docstring appears in Pydantic `_enums.py`, Rust `///` comments, Zod JSDoc, and JSON Schema `description`
  - Regression guard: enums with no docstring still generate cleanly across all four targets
- [x] `uv run pytest tests/` — 411 passed, 2 skipped
- [x] `uv run pre-commit run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)