### PR TITLE
chore: bump version to 0.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "schema-gen"
-version = "0.3.2"
+version = "0.3.3"
 description = "Universal schema converter - define once, generate everywhere"
 readme = "README.md"
 authors = [

--- a/src/schema_gen/__init__.py
+++ b/src/schema_gen/__init__.py
@@ -17,5 +17,5 @@ Example:
 from .core.config import Config
 from .core.schema import Field, Schema
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 __all__ = ["Schema", "Field", "Config", "__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -2281,7 +2281,7 @@ wheels = [
 
 [[package]]
 name = "schema-gen"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bumps `pyproject.toml`, `__init__.py`, and `uv.lock` to `0.3.3`.
- Ships fixes merged via #72: #70 (Pydantic description quote escaping) and #71 (enum class docstring propagation to Pydantic / Rust / Zod / JSON Schema).

## Test plan
- [x] `uv lock` clean
- [x] pre-commit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)