### PR TITLE
fix: deterministic ordering of discovered schemas and enums

### DIFF
--- a/src/schema_gen/core/generator.py
+++ b/src/schema_gen/core/generator.py
@@ -61,8 +61,10 @@ class SchemaGenerationEngine:
         if not schema_dir.exists():
             raise FileNotFoundError(f"Schema directory not found: {schema_dir}")
 
-        # Find all Python files in the schema directory
-        schema_files = list(schema_dir.rglob("*.py"))
+        # Find all Python files in the schema directory.
+        # Sort for deterministic registration order — rglob yields
+        # filesystem-dependent order, which leaks into generated output.
+        schema_files = sorted(schema_dir.rglob("*.py"))
 
         if not schema_files:
             raise ValueError(f"No Python files found in {schema_dir}")

--- a/src/schema_gen/parsers/schema_parser.py
+++ b/src/schema_gen/parsers/schema_parser.py
@@ -154,7 +154,9 @@ class SchemaParser:
         for usr_field in usr_fields:
             _collect_enum(usr_field)
 
-        enums = list(seen_enums.values())
+        # Sort by name so generated output is deterministic across
+        # runs/environments regardless of field declaration order.
+        enums = sorted(seen_enums.values(), key=lambda e: e.name)
 
         # Extract variants if defined
         variants = {}
@@ -280,6 +282,9 @@ class SchemaParser:
         if all_errors:
             raise ValueError("Schema validation failed:\n" + "\n".join(all_errors))
 
+        # Sort by schema name so downstream generators emit files and
+        # index entries in a stable, environment-independent order.
+        usr_schemas.sort(key=lambda s: s.name)
         return usr_schemas
 
     def parse_schema_by_name(self, schema_name: str) -> USRSchema:

--- a/tests/test_deterministic_ordering.py
+++ b/tests/test_deterministic_ordering.py
@@ -1,0 +1,65 @@
+"""Regression tests for deterministic ordering of discovered schemas and enums.
+
+Filesystem walk order (``Path.rglob``) and ``@Schema`` registration order
+are environment-dependent, so two regenerations on different machines
+could previously emit ``_enums.py`` / ``index.ts`` with different class
+or export ordering. We now sort by name at the parser boundary.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel
+
+from schema_gen.core.schema import Schema, SchemaRegistry
+from schema_gen.parsers.schema_parser import SchemaParser
+
+
+class ZColor(Enum):
+    RED = "red"
+
+
+class AStatus(Enum):
+    ON = "on"
+
+
+class MKind(Enum):
+    K = "k"
+
+
+def _reset_registry() -> None:
+    SchemaRegistry._schemas.clear()
+
+
+def test_parse_all_schemas_sorted_by_name() -> None:
+    _reset_registry()
+
+    @Schema
+    class Zeta(BaseModel):
+        x: int
+
+    @Schema
+    class Alpha(BaseModel):
+        x: int
+
+    @Schema
+    class Mu(BaseModel):
+        x: int
+
+    names = [s.name for s in SchemaParser().parse_all_schemas()]
+    assert names == ["Alpha", "Mu", "Zeta"]
+
+
+def test_parse_schema_enums_sorted_by_name() -> None:
+    _reset_registry()
+
+    @Schema
+    class Thing(BaseModel):
+        # Declare fields so enums are encountered in a non-alphabetical order.
+        c: ZColor
+        s: AStatus
+        k: MKind
+
+    usr = SchemaParser().parse_schema(Thing)
+    assert [e.name for e in usr.enums] == ["AStatus", "MKind", "ZColor"]


### PR DESCRIPTION
## Summary

- Sort `Path.rglob` results before importing schema modules
- Sort `USRSchemas` by name in `parse_all_schemas`
- Sort per-schema `enums` by name in `parse_schema`

`Path.rglob` and `@Schema` registration order are filesystem-dependent, so two regenerations on different machines were emitting `_enums.py` and `zod/index.ts` with different class/export ordering. Downstream consumers (e.g. tradingcore `contract-staleness.yml`) flagged false-positive drift on every PR.

Sorting at the parser boundary means all generators inherit a stable order with no per-generator changes.

Closes #74

## Test plan

- [x] `pytest -x -q` — 413 passed, 2 skipped
- [x] New regression test `tests/test_deterministic_ordering.py` covers both the schema- and enum-level ordering invariants

🤖 Generated with [Claude Code](https://claude.com/claude-code)