### PR TITLE
chore: bump version to 0.3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "schema-gen"
-version = "0.3.3"
+version = "0.3.4"
 description = "Universal schema converter - define once, generate everywhere"
 readme = "README.md"
 authors = [

--- a/src/schema_gen/__init__.py
+++ b/src/schema_gen/__init__.py
@@ -17,5 +17,5 @@ Example:
 from .core.config import Config
 from .core.schema import Field, Schema
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 __all__ = ["Schema", "Field", "Config", "__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -2281,7 +2281,7 @@ wheels = [
 
 [[package]]
 name = "schema-gen"
-version = "0.3.3"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Bump version `0.3.3` → `0.3.4`
- Releases the deterministic schema/enum ordering fix (#74, #75)

🤖 Generated with [Claude Code](https://claude.com/claude-code)