### PR TITLE
fix: remove per-file Generated at timestamps; keep only in registry.json

### DIFF
--- a/src/schema_gen/cli/main.py
+++ b/src/schema_gen/cli/main.py
@@ -1,6 +1,5 @@
 """Main CLI entry point for schema-gen"""
 
-import re
 import time
 from pathlib import Path
 
@@ -13,14 +12,6 @@ from ..diff.baseline import BaselineError, load_baseline, load_current
 from ..diff.comparator import compare_schemas
 from ..diff.formatter import format_github, format_json, format_text
 from ..diff.rules import RuleId, StrictnessLevel
-
-# Pattern to match timestamp lines across all generators
-_TIMESTAMP_RE = re.compile(r"^.*Generated at:.*$", re.MULTILINE)
-
-
-def _normalize_generated(content: str) -> str:
-    """Strip timestamp lines so content can be compared across runs."""
-    return _TIMESTAMP_RE.sub("", content).strip()
 
 
 class SchemaWatcher(FileSystemEventHandler):
@@ -322,9 +313,7 @@ def validate(config_path):
 
                 actual_content = actual_path.read_text()
 
-                if _normalize_generated(expected_content) != _normalize_generated(
-                    actual_content
-                ):
+                if expected_content != actual_content:
                     click.echo(f"  OUT-OF-DATE: {target}/{filename}")
                     validation_passed = False
                 else:

--- a/src/schema_gen/generators/avro_generator.py
+++ b/src/schema_gen/generators/avro_generator.py
@@ -1,7 +1,6 @@
 """Generator to create Apache Avro schemas from USR schemas"""
 
 import json
-from datetime import datetime
 from typing import Any
 
 from ..core.usr import FieldType, USRField, USRSchema
@@ -60,13 +59,10 @@ class AvroGenerator(BaseGenerator):
             Complete Avro schema file content (JSON)
         """
         # For Avro, we'll create a schema collection with all variants
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC")
-
         schema_collection = {
             "_meta": {
                 "generator": "schema-gen Avro generator",
                 "generated_from": schema.name,
-                "generated_at": timestamp,
                 "note": "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY",
             },
             "schemas": [],

--- a/src/schema_gen/generators/dataclasses_generator.py
+++ b/src/schema_gen/generators/dataclasses_generator.py
@@ -1,6 +1,5 @@
 """Generator to create Python dataclasses from USR schemas"""
 
-from datetime import datetime
 from pathlib import Path
 
 from jinja2 import Template
@@ -102,7 +101,6 @@ class DataclassesGenerator(BaseGenerator):
             description=schema.description,
             imports=sorted(imports),
             fields=field_definitions,
-            timestamp=datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC"),
         )
 
     def generate_file(self, schema: USRSchema) -> str:
@@ -400,13 +398,10 @@ class DataclassesGenerator(BaseGenerator):
         self, schema_name: str, imports: set, dataclasses: list[str]
     ) -> str:
         """Generate complete file with header, imports, and all dataclasses"""
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC")
-
         lines = [
             '"""',
             "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY",
             f"Generated from: {schema_name}",
-            f"Generated at: {timestamp}",
             "Generator: schema-gen Dataclasses generator",
             "",
             "To regenerate this file, run:",
@@ -463,7 +458,6 @@ class DataclassesGenerator(BaseGenerator):
         return '''"""
 AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
 Generated from: {{ schema_name }}{% if variant_name %} ({{ variant_name }} variant){% endif %}
-Generated at: {{ timestamp }}
 Generator: schema-gen Dataclasses generator
 
 To regenerate this file, run:

--- a/src/schema_gen/generators/graphql_generator.py
+++ b/src/schema_gen/generators/graphql_generator.py
@@ -1,7 +1,5 @@
 """Generator to create GraphQL schema from USR schemas"""
 
-from datetime import datetime
-
 from ..core.usr import FieldType, USRField, USRSchema
 from .base import BaseGenerator
 
@@ -66,12 +64,10 @@ class GraphQLGenerator(BaseGenerator):
         lines = []
 
         # Add header comment
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC")
         lines.extend(
             [
                 "# AUTO-GENERATED FILE - DO NOT EDIT MANUALLY",
                 f"# Generated from: {schema.name}",
-                f"# Generated at: {timestamp}",
                 "# Generator: schema-gen GraphQL generator",
                 "#",
                 "# To regenerate this file, run:",

--- a/src/schema_gen/generators/jackson_generator.py
+++ b/src/schema_gen/generators/jackson_generator.py
@@ -1,7 +1,5 @@
 """Generator to create Java classes with Jackson annotations from USR schemas"""
 
-from datetime import datetime
-
 from ..core.usr import FieldType, USRField, USRSchema
 from .base import BaseGenerator
 
@@ -54,13 +52,11 @@ class JacksonGenerator(BaseGenerator):
         lines = []
 
         # Add file header
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC")
         lines.extend(
             [
                 "/**",
                 " * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY",
                 f" * Generated from: {schema.name}",
-                f" * Generated at: {timestamp}",
                 " * Generator: schema-gen Jackson generator",
                 " *",
                 " * To regenerate this file, run:",

--- a/src/schema_gen/generators/kotlin_generator.py
+++ b/src/schema_gen/generators/kotlin_generator.py
@@ -1,7 +1,5 @@
 """Generator to create Kotlin data classes from USR schemas"""
 
-from datetime import datetime
-
 from ..core.usr import FieldType, USRField, USRSchema
 from .base import BaseGenerator
 
@@ -50,13 +48,11 @@ class KotlinGenerator(BaseGenerator):
         lines = []
 
         # Add file header
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC")
         lines.extend(
             [
                 "/**",
                 " * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY",
                 f" * Generated from: {schema.name}",
-                f" * Generated at: {timestamp}",
                 " * Generator: schema-gen Kotlin generator",
                 " *",
                 " * To regenerate this file, run:",

--- a/src/schema_gen/generators/pathway_generator.py
+++ b/src/schema_gen/generators/pathway_generator.py
@@ -1,6 +1,5 @@
 """Generator to create Pathway schemas from USR schemas"""
 
-from datetime import datetime
 from pathlib import Path
 
 from jinja2 import Template
@@ -85,7 +84,6 @@ class PathwayGenerator(BaseGenerator):
             description=schema.description,
             imports=sorted(imports),
             columns=column_definitions,
-            timestamp=datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC"),
         )
 
     def generate_file(self, schema: USRSchema) -> str:
@@ -271,13 +269,10 @@ class PathwayGenerator(BaseGenerator):
         self, schema_name: str, imports: set, schemas: list[str]
     ) -> str:
         """Generate complete file with header, imports, and all schemas"""
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC")
-
         lines = [
             '"""',
             "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY",
             f"Generated from: {schema_name}",
-            f"Generated at: {timestamp}",
             "Generator: schema-gen Pathway generator",
             "",
             "To regenerate this file, run:",
@@ -320,7 +315,6 @@ class PathwayGenerator(BaseGenerator):
         return '''"""
 AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
 Generated from: {{ schema_name }}{% if variant_name %} ({{ variant_name }} variant){% endif %}
-Generated at: {{ timestamp }}
 Generator: schema-gen Pathway generator
 
 To regenerate this file, run:

--- a/src/schema_gen/generators/protobuf_generator.py
+++ b/src/schema_gen/generators/protobuf_generator.py
@@ -1,7 +1,5 @@
 """Generator to create Protocol Buffers schemas from USR schemas"""
 
-from datetime import datetime
-
 from ..core.usr import FieldType, USRField, USRSchema
 from .base import BaseGenerator
 
@@ -66,12 +64,10 @@ class ProtobufGenerator(BaseGenerator):
         lines = []
 
         # Add proto file header
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC")
         lines.extend(
             [
                 "// AUTO-GENERATED FILE - DO NOT EDIT MANUALLY",
                 f"// Generated from: {schema.name}",
-                f"// Generated at: {timestamp}",
                 "// Generator: schema-gen Protobuf generator",
                 "//",
                 "// To regenerate this file, run:",

--- a/src/schema_gen/generators/pydantic_generator.py
+++ b/src/schema_gen/generators/pydantic_generator.py
@@ -1,7 +1,6 @@
 """Generator to create Pydantic models from USR schemas"""
 
 import json
-from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -123,12 +122,10 @@ class PydanticGenerator(BaseGenerator):
         self._shared_enum_names = set(seen.keys())
 
         # Build _enums.py content
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC")
         lines = [
             '"""',
             "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY",
             "Shared enum definitions for generated Pydantic models",
-            f"Generated at: {timestamp}",
             "Generator: schema-gen Pydantic generator",
             "",
             "To regenerate this file, run:",
@@ -241,7 +238,6 @@ class PydanticGenerator(BaseGenerator):
             fields=field_definitions,
             has_config=self._needs_config(fields),
             model_config_line=self._get_model_config_line(),
-            timestamp=datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC"),
         )
 
     def generate_all_variants(self, schema: USRSchema) -> dict[str, str]:
@@ -644,7 +640,6 @@ class PydanticGenerator(BaseGenerator):
         self_ref_model: str | None = None,
     ) -> str:
         """Generate complete file with header, imports, and all models"""
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC")
         custom_code = custom_code or {}
         enums = enums or []
 
@@ -652,7 +647,6 @@ class PydanticGenerator(BaseGenerator):
             '"""',
             "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY",
             f"Generated from: {schema_name}",
-            f"Generated at: {timestamp}",
             "Generator: schema-gen Pydantic generator",
             "",
             "To regenerate this file, run:",
@@ -780,7 +774,6 @@ class PydanticGenerator(BaseGenerator):
         return '''"""
 AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
 Generated from: {{ schema_name }}{% if variant_name %} ({{ variant_name }} variant){% endif %}
-Generated at: {{ timestamp }}
 Generator: schema-gen Pydantic generator
 
 To regenerate this file, run:

--- a/src/schema_gen/generators/sqlalchemy_generator.py
+++ b/src/schema_gen/generators/sqlalchemy_generator.py
@@ -1,6 +1,5 @@
 """Generator to create SQLAlchemy 2.0 models from USR schemas"""
 
-from datetime import datetime
 from enum import Enum
 from pathlib import Path
 
@@ -99,7 +98,6 @@ class SqlAlchemyGenerator(BaseGenerator):
             imports=sorted(imports),
             columns=column_definitions,
             relationships=relationships,
-            timestamp=datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC"),
         )
 
     def generate_file(self, schema: USRSchema) -> str:
@@ -315,13 +313,10 @@ class SqlAlchemyGenerator(BaseGenerator):
         description: str,
     ) -> str:
         """Generate complete file with header, imports, and model"""
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC")
-
         lines = [
             '"""',
             "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY",
             f"Generated from: {schema_name}",
-            f"Generated at: {timestamp}",
             "Generator: schema-gen SQLAlchemy generator",
             "",
             "To regenerate this file, run:",
@@ -441,7 +436,6 @@ class SqlAlchemyGenerator(BaseGenerator):
         return '''"""
 AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
 Generated from: {{ schema_name }}{% if variant_name %} ({{ variant_name }} variant){% endif %}
-Generated at: {{ timestamp }}
 Generator: schema-gen SQLAlchemy generator
 
 To regenerate this file, run:

--- a/src/schema_gen/generators/typeddict_generator.py
+++ b/src/schema_gen/generators/typeddict_generator.py
@@ -1,6 +1,5 @@
 """Generator to create Python TypedDict from USR schemas"""
 
-from datetime import datetime
 from pathlib import Path
 
 from jinja2 import Template
@@ -91,7 +90,6 @@ class TypedDictGenerator(BaseGenerator):
             imports=sorted(imports),
             fields=field_definitions,
             has_optional_fields=has_optional_fields,
-            timestamp=datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC"),
         )
 
     def generate_file(self, schema: USRSchema) -> str:
@@ -320,13 +318,10 @@ class TypedDictGenerator(BaseGenerator):
         self, schema_name: str, imports: set, typeddicts: list[str]
     ) -> str:
         """Generate complete file with header, imports, and all TypedDicts"""
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC")
-
         lines = [
             '"""',
             "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY",
             f"Generated from: {schema_name}",
-            f"Generated at: {timestamp}",
             "Generator: schema-gen TypedDict generator",
             "",
             "To regenerate this file, run:",
@@ -379,7 +374,6 @@ class TypedDictGenerator(BaseGenerator):
         return '''"""
 AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
 Generated from: {{ schema_name }}{% if variant_name %} ({{ variant_name }} variant){% endif %}
-Generated at: {{ timestamp }}
 Generator: schema-gen TypedDict generator
 
 To regenerate this file, run:

--- a/src/schema_gen/generators/zod_generator.py
+++ b/src/schema_gen/generators/zod_generator.py
@@ -1,7 +1,6 @@
 """Generator to create Zod schemas from USR schemas"""
 
 import logging
-from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -175,7 +174,6 @@ class ZodGenerator(BaseGenerator):
             variant_name=variant,
             description=schema.description,
             fields=field_definitions,
-            timestamp=datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC"),
         )
 
     def generate_all_variants(self, schema: USRSchema) -> dict[str, str]:
@@ -528,7 +526,6 @@ class ZodGenerator(BaseGenerator):
         external_refs: set[str] | None = None,
     ) -> str:
         """Generate complete TypeScript file with header, imports, and all schemas"""
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC")
         enums = enums or []
         external_refs = external_refs or set()
 
@@ -536,7 +533,6 @@ class ZodGenerator(BaseGenerator):
             "/**",
             " * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY",
             f" * Generated from: {schema_name}",
-            f" * Generated at: {timestamp}",
             " * Generator: schema-gen Zod generator",
             " *",
             " * To regenerate this file, run:",
@@ -600,7 +596,6 @@ class ZodGenerator(BaseGenerator):
         return """/**
  * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
  * Generated from: {{ base_schema_name }}{% if variant_name %} ({{ variant_name }} variant){% endif %}
- * Generated at: {{ timestamp }}
  * Generator: schema-gen Zod generator
  *
  * To regenerate this file, run:


### PR DESCRIPTION
## Summary
- Removes `Generated at: <timestamp>` from all 11 generator file headers (pydantic, dataclasses, sqlalchemy, pathway, zod, typeddict, protobuf, kotlin, jackson, graphql, avro)
- `registry.json` retains `generated_at` and `schema_gen_version` as the canonical provenance record
- Removes the `_normalize_generated` workaround from the `validate` command since timestamps no longer appear in generated files
- Cleans up now-unused `from datetime import datetime` imports across all affected generators

## Test plan
- [ ] All 413 existing tests pass
- [ ] Regenerating schemas twice should produce bit-identical output for all files except `registry.json`
- [ ] `schema-gen validate` continues to work correctly with direct string comparison

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)