### PR TITLE
fix(rust-gen): emit #[serde(rename)] for non-snake_case field names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "schema-gen"
-version = "0.3.4"
+version = "0.3.5"
 description = "Universal schema converter - define once, generate everywhere"
 readme = "README.md"
 authors = [

--- a/src/schema_gen/__init__.py
+++ b/src/schema_gen/__init__.py
@@ -17,5 +17,5 @@ Example:
 from .core.config import Config
 from .core.schema import Field, Schema
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"
 __all__ = ["Schema", "Field", "Config", "__version__"]

--- a/src/schema_gen/generators/rust_generator.py
+++ b/src/schema_gen/generators/rust_generator.py
@@ -127,6 +127,11 @@ def _rust_field_ident(name: str) -> str:
     against :data:`_RUST_RESERVED_WORDS` and escaped with ``r#`` if needed
     (e.g. the schema field ``TYPE`` normalises to ``type``).
 
+    Note: :func:`_snake_case` strips leading underscores from the name before
+    converting, consistent with its struct-name behavior.  Schema field names
+    that start with ``_`` will therefore have the prefix dropped in the emitted
+    Rust identifier (the serde rename preserves the original wire key).
+
     Use :func:`_rust_field_wire_name` to determine whether a rename attribute
     is needed.
     """
@@ -140,13 +145,12 @@ def _rust_field_ident(name: str) -> str:
     # snake_case by lowercasing after word boundaries, then squash any double
     # underscores that arise when uppercase sequences are preceded or followed
     # by an existing underscore (e.g. ``ratio_CE_otm`` → ``ratio__ce_otm`` →
-    # ``ratio_ce_otm``).  Do NOT strip leading/trailing underscores: doing so
-    # can silently collapse a safe identifier (e.g. ``Type_``) into a reserved
-    # keyword (``type``).
+    # ``ratio_ce_otm``).
     if any(c.isupper() for c in name):
         snake = _snake_case(name)
         snake = re.sub(r"_+", "_", snake)
-        # Re-check: normalisation may have produced a reserved keyword.
+        # Re-check: normalisation may have produced a reserved keyword
+        # (e.g. the field ``TYPE`` normalises to ``type``).
         if snake in _RUST_RESERVED_WORDS:
             return f"r#{snake}"
         return snake
@@ -642,10 +646,10 @@ class RustGenerator(BaseGenerator):
         seen_idents: dict[str, str] = {}
         for field in fields:
             ident = _rust_field_ident(field.name)
-            # Strip the r# prefix when checking for collisions so that
+            # Strip the exact r# prefix when checking for collisions so that
             # ``r#type`` and ``type`` (impossible in practice, but defensive)
             # are treated as the same identifier.
-            bare = ident.lstrip("r#") if ident.startswith("r#") else ident
+            bare = ident[2:] if ident.startswith("r#") else ident
             if bare in seen_idents:
                 msg = (
                     f"Schema '{struct_name}': fields '{seen_idents[bare]}' and "

--- a/src/schema_gen/generators/rust_generator.py
+++ b/src/schema_gen/generators/rust_generator.py
@@ -120,8 +120,9 @@ def _rust_field_ident(name: str) -> str:
 
     - Reserved words (e.g. ``type``) → ``r#type`` with ``#[serde(rename)]``.
     - Non-snake_case names (e.g. ``theta_vega_ratio_CE_otm``) → lowercased
-      with double-underscores squashed (``theta_vega_ratio_ce_otm``); caller
-      must add ``#[serde(rename = "<original>")]`` to preserve the wire format.
+      with consecutive underscores collapsed (``theta_vega_ratio_ce_otm``);
+      caller must add ``#[serde(rename = "<original>")]`` to preserve the
+      wire format.
 
     After snake_case normalization the resulting identifier is re-checked
     against :data:`_RUST_RESERVED_WORDS` and escaped with ``r#`` if needed
@@ -142,10 +143,10 @@ def _rust_field_ident(name: str) -> str:
 
     # If the name contains uppercase letters it is not valid Rust snake_case
     # and ``rustc`` will emit a ``non_snake_case`` warning.  Convert to proper
-    # snake_case by lowercasing after word boundaries, then squash any double
-    # underscores that arise when uppercase sequences are preceded or followed
-    # by an existing underscore (e.g. ``ratio_CE_otm`` → ``ratio__ce_otm`` →
-    # ``ratio_ce_otm``).
+    # snake_case by lowercasing after word boundaries, then collapse any run of
+    # consecutive underscores to a single underscore that arise when uppercase
+    # sequences are preceded or followed by an existing underscore
+    # (e.g. ``ratio_CE_otm`` → ``ratio__ce_otm`` → ``ratio_ce_otm``).
     if any(c.isupper() for c in name):
         snake = _snake_case(name)
         snake = re.sub(r"_+", "_", snake)

--- a/src/schema_gen/generators/rust_generator.py
+++ b/src/schema_gen/generators/rust_generator.py
@@ -117,10 +117,15 @@ def _rust_field_ident(name: str) -> str:
     """Return the Rust identifier for a field name.
 
     Handles two cases:
+
     - Reserved words (e.g. ``type``) → ``r#type`` with ``#[serde(rename)]``.
     - Non-snake_case names (e.g. ``theta_vega_ratio_CE_otm``) → lowercased
-      with underscores squashed (``theta_vega_ratio_ce_otm``); caller must
-      add ``#[serde(rename = "<original>")]`` to preserve the wire format.
+      with double-underscores squashed (``theta_vega_ratio_ce_otm``); caller
+      must add ``#[serde(rename = "<original>")]`` to preserve the wire format.
+
+    After snake_case normalization the resulting identifier is re-checked
+    against :data:`_RUST_RESERVED_WORDS` and escaped with ``r#`` if needed
+    (e.g. the schema field ``TYPE`` normalises to ``type``).
 
     Use :func:`_rust_field_wire_name` to determine whether a rename attribute
     is needed.
@@ -135,10 +140,15 @@ def _rust_field_ident(name: str) -> str:
     # snake_case by lowercasing after word boundaries, then squash any double
     # underscores that arise when uppercase sequences are preceded or followed
     # by an existing underscore (e.g. ``ratio_CE_otm`` → ``ratio__ce_otm`` →
-    # ``ratio_ce_otm``).
+    # ``ratio_ce_otm``).  Do NOT strip leading/trailing underscores: doing so
+    # can silently collapse a safe identifier (e.g. ``Type_``) into a reserved
+    # keyword (``type``).
     if any(c.isupper() for c in name):
         snake = _snake_case(name)
-        snake = re.sub(r"_+", "_", snake).strip("_")
+        snake = re.sub(r"_+", "_", snake)
+        # Re-check: normalisation may have produced a reserved keyword.
+        if snake in _RUST_RESERVED_WORDS:
+            return f"r#{snake}"
         return snake
 
     return name
@@ -624,6 +634,26 @@ class RustGenerator(BaseGenerator):
             lines.append(f"#[serde({', '.join(serde_struct_attrs)})]")
 
         lines.append(f"pub struct {struct_name} {{")
+
+        # Detect identifier collisions before generating — two schema fields
+        # can normalise to the same Rust snake_case identifier (e.g.
+        # ``ratio_CE_otm`` and ``ratio_ce_otm`` both → ``ratio_ce_otm``).
+        # Fail fast with a clear message rather than emitting invalid Rust.
+        seen_idents: dict[str, str] = {}
+        for field in fields:
+            ident = _rust_field_ident(field.name)
+            # Strip the r# prefix when checking for collisions so that
+            # ``r#type`` and ``type`` (impossible in practice, but defensive)
+            # are treated as the same identifier.
+            bare = ident.lstrip("r#") if ident.startswith("r#") else ident
+            if bare in seen_idents:
+                msg = (
+                    f"Schema '{struct_name}': fields '{seen_idents[bare]}' and "
+                    f"'{field.name}' both normalise to the Rust identifier "
+                    f"'{ident}'. Rename one field in the schema source."
+                )
+                raise ValueError(msg)
+            seen_idents[bare] = field.name
 
         field_lines: list[str] = []
         for field in fields:

--- a/src/schema_gen/generators/rust_generator.py
+++ b/src/schema_gen/generators/rust_generator.py
@@ -114,10 +114,51 @@ _VALID_RUST_FLOAT_TYPES = frozenset({"f32", "f64"})
 
 
 def _rust_field_ident(name: str) -> str:
-    """Return the Rust identifier for a field name, escaping reserved words."""
+    """Return the Rust identifier for a field name.
+
+    Handles two cases:
+    - Reserved words (e.g. ``type``) → ``r#type`` with ``#[serde(rename)]``.
+    - Non-snake_case names (e.g. ``theta_vega_ratio_CE_otm``) → lowercased
+      with underscores squashed (``theta_vega_ratio_ce_otm``); caller must
+      add ``#[serde(rename = "<original>")]`` to preserve the wire format.
+
+    Use :func:`_rust_field_wire_name` to determine whether a rename attribute
+    is needed.
+    """
+    import re  # noqa: PLC0415 — local import to avoid module-level churn
+
     if name in _RUST_RESERVED_WORDS:
         return f"r#{name}"
+
+    # If the name contains uppercase letters it is not valid Rust snake_case
+    # and ``rustc`` will emit a ``non_snake_case`` warning.  Convert to proper
+    # snake_case by lowercasing after word boundaries, then squash any double
+    # underscores that arise when uppercase sequences are preceded or followed
+    # by an existing underscore (e.g. ``ratio_CE_otm`` → ``ratio__ce_otm`` →
+    # ``ratio_ce_otm``).
+    if any(c.isupper() for c in name):
+        snake = _snake_case(name)
+        snake = re.sub(r"_+", "_", snake).strip("_")
+        return snake
+
     return name
+
+
+def _rust_field_wire_name(name: str) -> str | None:
+    """Return the original wire-format name when a ``#[serde(rename)]`` is needed.
+
+    Returns ``name`` when the Rust identifier differs from the original field
+    name (reserved-word escape or non-snake_case conversion), ``None`` when
+    no rename attribute is required.
+    """
+    ident = _rust_field_ident(name)
+    # r#foo → the Rust identifier differs; wire name is bare ``foo``.
+    if name in _RUST_RESERVED_WORDS:
+        return name
+    # Non-snake_case → the Rust ident was lowercased; wire name is original.
+    if ident != name:
+        return name
+    return None
 
 
 _DEFAULT_STRUCT_DERIVES = [
@@ -615,8 +656,9 @@ class RustGenerator(BaseGenerator):
         name = field.name
         emitted_name = _rust_field_ident(name)
 
-        if name in _RUST_RESERVED_WORDS:
-            serde_attrs.append(f'rename = "{name}"')
+        wire_name = _rust_field_wire_name(name)
+        if wire_name is not None:
+            serde_attrs.append(f'rename = "{wire_name}"')
 
         if is_optional:
             serde_attrs.append('skip_serializing_if = "Option::is_none"')

--- a/tests/test_rust_generator.py
+++ b/tests/test_rust_generator.py
@@ -1352,3 +1352,33 @@ class TestNonSnakeCaseFieldRename:
 
         assert "pub r#type: String," in out
         assert '#[serde(rename = "type")]' in out
+
+    def test_uppercase_normalisation_to_reserved_word_is_escaped(self):
+        """A field ``TYPE`` normalises to the reserved word ``type``.
+
+        The generator must escape it as ``r#type`` and preserve the wire
+        format via ``#[serde(rename = "TYPE")]``.
+        """
+
+        @Schema
+        class ReservedAfterNorm:
+            TYPE: str
+            value: int
+
+        schema = SchemaParser().parse_schema(ReservedAfterNorm)
+        out = RustGenerator().generate_file(schema)
+
+        assert "pub r#type: String," in out
+        assert '#[serde(rename = "TYPE")]' in out
+
+    def test_colliding_idents_raise(self):
+        """Two schema fields that normalise to the same Rust identifier must raise."""
+        schema = USRSchema(
+            name="CollidingFields",
+            fields=[
+                USRField(name="ratio_ce_otm", type=FieldType.FLOAT, python_type=float),
+                USRField(name="ratio_CE_otm", type=FieldType.FLOAT, python_type=float),
+            ],
+        )
+        with pytest.raises(ValueError, match="normalise to the Rust identifier"):
+            RustGenerator().generate_file(schema)

--- a/tests/test_rust_generator.py
+++ b/tests/test_rust_generator.py
@@ -1282,6 +1282,9 @@ class TestNonSnakeCaseFieldRename:
     ``#[serde(rename = "<original>")]`` attribute so the JSON wire format is
     preserved while the Rust code stays ``non_snake_case``-warning-free."""
 
+    def setup_method(self):
+        SchemaRegistry._schemas.clear()
+
     def test_uppercase_acronym_in_snake_field_gets_rename(self):
         """Embedded uppercase acronym (CE, PE) → rename + lowercased ident."""
 

--- a/tests/test_rust_generator.py
+++ b/tests/test_rust_generator.py
@@ -1269,3 +1269,86 @@ class TestDiscriminatorErrors:
         usr = SchemaParser().parse_schema(_GoodDiscHolder)
         assert usr.fields[0].discriminator == "tag"
         assert usr.fields[0].union_tag_values == ["v1", "v2"]
+
+
+# ----------------------------------------------------------------------
+# Fix: non-snake_case field names emit #[serde(rename)] + snake_case ident
+# ----------------------------------------------------------------------
+
+
+class TestNonSnakeCaseFieldRename:
+    """Fields with uppercase letters (e.g. ``theta_vega_ratio_CE_otm``) must
+    be emitted as a lowercased snake_case Rust identifier accompanied by a
+    ``#[serde(rename = "<original>")]`` attribute so the JSON wire format is
+    preserved while the Rust code stays ``non_snake_case``-warning-free."""
+
+    def test_uppercase_acronym_in_snake_field_gets_rename(self):
+        """Embedded uppercase acronym (CE, PE) → rename + lowercased ident."""
+
+        @Schema
+        class GreeksRatio:
+            theta_vega_ratio_CE_otm: float
+            theta_vega_ratio_PE_otm: float
+            normal_field: float
+
+        schema = SchemaParser().parse_schema(GreeksRatio)
+        out = RustGenerator().generate_file(schema)
+
+        # CE/PE fields: rename preserves wire format, ident is lowercased.
+        assert '#[serde(rename = "theta_vega_ratio_CE_otm")]' in out
+        assert "pub theta_vega_ratio_ce_otm: f64," in out
+
+        assert '#[serde(rename = "theta_vega_ratio_PE_otm")]' in out
+        assert "pub theta_vega_ratio_pe_otm: f64," in out
+
+        # Normal field: no redundant rename attribute.
+        assert "pub normal_field: f64," in out
+        assert '#[serde(rename = "normal_field")]' not in out
+
+    def test_optional_non_snake_case_field_preserves_skip_serializing(self):
+        """Optional non-snake_case fields must have BOTH rename and skip_serializing_if."""
+
+        @Schema
+        class GreeksOpt:
+            theta_vega_ratio_CE_otm: float | None = None
+
+        schema = SchemaParser().parse_schema(GreeksOpt)
+        out = RustGenerator().generate_file(schema)
+
+        # Both serde attributes must appear together on one line.
+        assert (
+            '#[serde(rename = "theta_vega_ratio_CE_otm", skip_serializing_if = "Option::is_none")]'
+            in out
+        )
+        assert "pub theta_vega_ratio_ce_otm: Option<f64>," in out
+
+    def test_already_snake_case_no_rename(self):
+        """Fields already in valid snake_case must not gain a rename attribute."""
+
+        @Schema
+        class Clean:
+            spot_ltp: float
+            gex_total: float
+
+        schema = SchemaParser().parse_schema(Clean)
+        out = RustGenerator().generate_file(schema)
+
+        assert "pub spot_ltp: f64," in out
+        assert "pub gex_total: f64," in out
+        # No spurious renames.
+        assert '#[serde(rename = "spot_ltp")]' not in out
+        assert '#[serde(rename = "gex_total")]' not in out
+
+    def test_reserved_word_field_rename_still_works(self):
+        """Reserved-word fields (``type``) must still emit r# escape + rename."""
+
+        @Schema
+        class WithType:
+            type: str
+            value: int
+
+        schema = SchemaParser().parse_schema(WithType)
+        out = RustGenerator().generate_file(schema)
+
+        assert "pub r#type: String," in out
+        assert '#[serde(rename = "type")]' in out


### PR DESCRIPTION
## Summary

- Fields containing uppercase letters (e.g. `theta_vega_ratio_CE_otm`) were emitted with their original name, triggering `rustc` `non_snake_case` warnings
- The Rust generator now converts such identifiers to proper snake_case AND adds `#[serde(rename = "<original>")]` to preserve the JSON wire format
- Covers both the reserved-word path (unchanged behavior) and the new non-snake_case path uniformly via the new `_rust_field_wire_name` helper

## Changes

- `_rust_field_ident`: now lowercases field names that contain uppercase letters, squashing double-underscores (e.g. `ratio_CE_otm` → `ratio_ce_otm`)
- `_rust_field_wire_name`: new helper that returns the original name when a `#[serde(rename)]` is needed, `None` otherwise
- `_generate_field`: uses `_rust_field_wire_name` instead of the old `_RUST_RESERVED_WORDS` check
- 4 new tests: acronym rename, optional+rename+skip_serializing_if, clean snake_case (no spurious rename), reserved word regression

## Test plan

- [ ] All 413 existing tests pass (`pytest tests/ --ignore=tests/test_e2e_compile.py`)
- [ ] 4 new tests in `TestNonSnakeCaseFieldRename` cover the fix
- [ ] Fields like `theta_vega_ratio_CE_otm` get `#[serde(rename = "theta_vega_ratio_CE_otm")] pub theta_vega_ratio_ce_otm: f64,`
- [ ] Already-snake_case fields get no spurious rename attribute

Fixes: jagatsingh/tradingcore#294

🤖 Generated with [Claude Code](https://claude.com/claude-code)