### PR TITLE
chore: bump version to 0.3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "schema-gen"
-version = "0.3.5"
+version = "0.3.6"
 description = "Universal schema converter - define once, generate everywhere"
 readme = "README.md"
 authors = [

--- a/src/schema_gen/__init__.py
+++ b/src/schema_gen/__init__.py
@@ -17,5 +17,5 @@ Example:
 from .core.config import Config
 from .core.schema import Field, Schema
 
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 __all__ = ["Schema", "Field", "Config", "__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[options]
+exclude-newer = "2026-04-14T07:19:31Z"
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -2281,7 +2284,7 @@ wheels = [
 
 [[package]]
 name = "schema-gen"
-version = "0.3.4"
+version = "0.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Publishes the fully-reviewed schema-gen 0.3.5 code (PR #80) as version 0.3.6 to Nexus
- The 0.3.5 wheel on Nexus was built from the initial fix commit before the 4-round Copilot review completed
- No logic changes — purely a version bump so the Nexus artifact matches the reviewed main branch code

## What's included in 0.3.6 (vs the 0.3.5 Nexus artifact)

All fixes from PR #80 review rounds that landed after the initial build:
1. Reserved-word re-check after normalization (`TYPE` → `r#type`)
2. Collision detection for fields that normalize to the same Rust identifier
3. `lstrip("r#")` → `[2:]` for correct prefix stripping
4. Docstring accuracy ("collapses repeated underscores" not "double-underscores")
5. Test isolation via `setup_method` clearing `SchemaRegistry._schemas`

## Test plan
- [x] 415 tests pass (`uv run pytest tests/`)
- [x] pre-commit clean
- [x] Wheel uploaded to Nexus at `http://localhost:5081/repository/pypi-local/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)