### PR TITLE
fix(renovate): customManagers fileMatch (fixes #85)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -166,8 +166,8 @@
     {
       customType: 'regex',
       description: 'Update versions in test matrix YAML',
-      managerFilePatterns: [
-        '/^tests/test-matrix\\.yml$/',
+      fileMatch: [
+        '^tests/test-matrix\\.yml$',
       ],
       matchStrings: [
         '\\s+-\\s+"(?<currentValue>[^"]+)"\\s*#.*(?<depName>pydantic|sqlalchemy|pathway|avro|protobuf|jsonschema|graphql-core)',
@@ -178,21 +178,22 @@
     {
       customType: 'regex',
       description: 'Update Python versions in workflows',
-      managerFilePatterns: [
-        '/^\\.github/workflows/.*\\.yml$/',
+      fileMatch: [
+        '^\\.github/workflows/.*\\.yml$',
       ],
       matchStrings: [
         'python-version:\\s*\\["(?<currentValue>[^"]+)"',
       ],
       depNameTemplate: 'python',
+      packageNameTemplate: 'python/cpython',
       datasourceTemplate: 'github-releases',
       extractVersionTemplate: '^v(?<version>.*)$',
     },
     {
       customType: 'regex',
       description: 'Update library versions in version compatibility workflow',
-      managerFilePatterns: [
-        '/^\\.github/workflows/version-compatibility\\.yml$/',
+      fileMatch: [
+        '^\\.github/workflows/version-compatibility\\.yml$',
       ],
       matchStrings: [
         '(?<depName>pydantic|sqlalchemy|pathway)-version:\\s*\\["(?<currentValue>[^"]+)"',


### PR DESCRIPTION
## Summary
`renovate --dry-run=full` on this repo reproduces the exact error driving issue #85:

```
Custom Manager contains disallowed fields: managerFilePatterns
Invalid configuration option: customManagers[0].managerFilePatterns
Invalid configuration option: customManagers[1].managerFilePatterns
Invalid configuration option: customManagers[2].managerFilePatterns
```

`customManagers[*]` only accepts `fileMatch`. `managerFilePatterns` is a different field reserved for top-level manager blocks (`pip-compile`, `dockerfile`, etc.). The config was silently failing validation before Renovate ever got to open PRs, which is why Renovate filed "Action Required: Fix Renovate Configuration" (#85) after it ran post-merge of PR #84.

## Changes
- Renamed `managerFilePatterns` → `fileMatch` in all 3 `customManagers` entries.
- Dropped `/…/ ` slash delimiters — `fileMatch` takes bare regex strings (slash-wrapped form is the `managerFilePatterns` convention).
- Added `packageNameTemplate: 'python/cpython'` to the Python-version custom manager so the `github-releases` datasource looks up the right repo. This fixes the `Failed to look up github-releases package python: no-result` warning that was showing in dependency dashboard #9.

## Test plan
- [x] `renovate --dry-run=full jagatsingh/schema-gen` now gets past config-validation.
- [ ] After merge, Renovate reopens the dependency dashboard on its next run without filing another "Action Required" issue.

Fixes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)