### PR TITLE
fix(renovate): disable pip-compile manager (fixes #88)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -162,6 +162,11 @@
   pep621: {
     enabled: true,
   },
+  // pip-compile is enabled by the tradingutils preset but this project
+  // uses uv.lock — docs/requirements.txt is plain, not pip-compile output.
+  'pip-compile': {
+    enabled: false,
+  },
   customManagers: [
     {
       customType: 'regex',


### PR DESCRIPTION
## Summary
Renovate dry-run on this repo surfaced two \"Repository problems\" contributing to issue #88:

1. **pip-compile error on docs/requirements.txt** — the tradingutils preset enables the pip-compile manager, which then tries to parse every `requirements.txt` for a pip-compile header. `docs/requirements.txt` is a plain requirements file (not pip-compile output), so extraction fails:
   ```
   WARN: pip-compile error
   errorMessage: Failed to extract command from header in docs/requirements.txt
   ```
   This project uses `uv.lock`, not pip-compile, so the manager serves no purpose here.

2. **Trailing comma in tradingutils/default.json** — fixed upstream in [jagatsingh/tradingutils#611](https://github.com/jagatsingh/tradingutils/pull/611) (merged). That removes the `WARN: File contents are invalid JSON but parse using JSON5` warning on every Renovate run here.

## Fix (this PR)
Explicitly disable the `pip-compile` manager in `renovate.json5`. `pep621` (which handles `pyproject.toml`) stays enabled.

## Test plan
- [x] Combined with the tradingutils fix, `renovate --dry-run=full jagatsingh/schema-gen` produces no \"Repository problems\" entries.
- [ ] Renovate's next scheduled run reopens the dependency dashboard without filing another \"Action Required\" issue.

Fixes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)