### PR TITLE
fix(renovate): drop private tradingutils preset, self-contain config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,7 +1,8 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
-    'github>jagatsingh/tradingutils',
+    'config:recommended',
+    ':semanticCommits',
     ':separatePatchReleases',
   ],
   schedule: [
@@ -151,6 +152,7 @@
       'security',
       'dependencies',
     ],
+    minimumReleaseAge: '0 days',
   },
   osvVulnerabilityAlerts: true,
   lockFileMaintenance: {


### PR DESCRIPTION
## Summary

- Fixes the Renovate 404 on this repo (issue #91): `jagatsingh/tradingutils` is private, so the Renovate App running on public `schema-gen` cannot read its preset. GitHub returns 404 for inaccessible private repos, which surfaces as the misleading `Preset file renovate.json not found`.
- Replaces the private extend with the two upstream presets it was supplying that aren't already configured inline: `config:recommended` (canonical baseline, replaces deprecated `config:base`) and `:semanticCommits`.
- Adds `minimumReleaseAge: "0 days"` under `vulnerabilityAlerts` so CVE fixes bypass the 7-day supply-chain delay — this came from the old preset and must not be lost.

## What's not re-added (already covered inline)

| Old preset rule | Where it's already covered |
|---|---|
| `:enableVulnerabilityAlertsWithLabel(security)` | `vulnerabilityAlerts.labels: ['security', 'dependencies']` |
| `helpers:pinGitHubActionDigests` | `pinDigests: true` packageRule on `github-actions` manager |
| `config:base` | Renamed to `config:recommended` in modern Renovate |
| `:dependencyDashboard` | Transitive via `config:recommended` |

## Behavioral drift vs. old tradingutils preset (intentional)

- The old preset had top-level `automerge: true`. The inline config keeps automerge narrow (dev-dep patches and GHA patches only). This is a safer posture, not a regression.
- Non-Python managers (`cargo`, `npm`, `poetry`, `setup-cfg`) and non-applicable package groupings (data-science-stack, arrow/parquet) from the old preset are dropped — schema-gen is a Python-only project, so they never matched anything anyway.

## Validation

- `renovate-config-validator renovate.json5` → `Config validated successfully`
- `pre-commit run --files renovate.json5` → all passed
- Local code-reviewer pass: approved.

## Test plan

- [ ] Wait for Renovate to run against this branch and confirm the onboarding/config-warning error clears.
- [ ] Verify the dependency-dashboard issue updates cleanly on next cycle.

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)