### PR TITLE
test(framework): close last 2 framework-execution skips (Rust + Kotlin classpath)

### DIFF
--- a/Dockerfile.validation
+++ b/Dockerfile.validation
@@ -117,6 +117,17 @@ RUN cd /opt/java-libs && \
 ENV CLASSPATH="/opt/java-libs/*"
 ENV JAVA_HOME="/usr/lib/jvm/default-java"
 
+# Kotlin classpath — points the test_kotlinc_accepts_output framework
+# test at the kotlinx-serialization runtime jars downloaded above so the
+# generated ``@Serializable`` annotation resolves at compile time.
+ENV KOTLIN_CLASSPATH="/opt/kotlin-libs/*"
+
+# Install Rust toolchain (cargo + rustc) for the Rust framework-execution
+# test (``cargo check`` on a generated lib.rs). ``--profile minimal``
+# skips docs/tests components to keep the layer small.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- --default-toolchain stable -y --profile minimal
+
 # Install Python package manager (uv)
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH="/root/.local/bin:/root/.cargo/bin:$PATH"

--- a/scripts/validate-in-docker.sh
+++ b/scripts/validate-in-docker.sh
@@ -43,7 +43,10 @@ if ! docker info >/dev/null 2>&1; then
   exit 2
 fi
 
-# --- Build the image if missing or --rebuild requested ----------------
+# --- Always run docker build (cached layers make it a no-op when -----
+# nothing has changed, and any Dockerfile edit is picked up
+# automatically). ``--rebuild`` adds ``--no-cache`` to force a clean
+# build from scratch. -------------------------------------------------
 
 REBUILD=0
 for arg in "$@"; do
@@ -52,10 +55,16 @@ for arg in "$@"; do
   esac
 done
 
-if [[ "$REBUILD" == 1 ]] || ! docker image inspect "$IMAGE_TAG" >/dev/null 2>&1; then
+BUILD_ARGS=()
+if [[ "$REBUILD" == 1 ]]; then
+  BUILD_ARGS+=(--no-cache)
+  echo "==> Forcing clean rebuild of $IMAGE_TAG (no-cache)..."
+elif docker image inspect "$IMAGE_TAG" >/dev/null 2>&1; then
+  echo "==> Refreshing $IMAGE_TAG from $DOCKERFILE (cached, fast if unchanged)..."
+else
   echo "==> Building $IMAGE_TAG from $DOCKERFILE (one-time, ~10 min)..."
-  DOCKER_BUILDKIT=1 docker build -f "$DOCKERFILE" -t "$IMAGE_TAG" "$REPO_ROOT"
 fi
+DOCKER_BUILDKIT=1 docker build -f "$DOCKERFILE" -t "$IMAGE_TAG" "${BUILD_ARGS[@]}" "$REPO_ROOT"
 
 # --- Run the framework-execution suite inside the container -----------
 #

--- a/tests/test_generator_framework_execution.py
+++ b/tests/test_generator_framework_execution.py
@@ -523,9 +523,21 @@ class TestKotlinFrameworkExecution:
         # users can do the same. When the runtime is missing, the @Serializable
         # annotation can't resolve and that's a tooling-environment issue,
         # not a generator bug — skip cleanly with a helpful message.
+        #
+        # ``kotlinc`` does NOT expand classpath wildcards (unlike ``javac``),
+        # so glob the value of ``KOTLIN_CLASSPATH`` ourselves and join with
+        # the platform-correct path separator. ``dir/*`` and explicit
+        # colon/semicolon-separated entries both work this way.
+        import glob
         import os
 
-        classpath = os.environ.get("KOTLIN_CLASSPATH", "")
+        raw_cp = os.environ.get("KOTLIN_CLASSPATH", "")
+        cp_entries: list[str] = []
+        for entry in raw_cp.split(os.pathsep):
+            if not entry:
+                continue
+            cp_entries.extend(glob.glob(entry) or [entry])
+        classpath = os.pathsep.join(cp_entries)
         cmd = ["kotlinc", "-nowarn", "-d", str(tmp_path / "out")]
         if classpath:
             cmd.extend(["-cp", classpath])


### PR DESCRIPTION
## Summary

After v0.3.9 shipped, running `scripts/validate-in-docker.sh` against the local image surfaced two real gaps where framework-execution silently skipped instead of running. Both fixed; the Docker image now has **zero skips** — all 13 generators have their real-framework checks actually exercising compilers/runtimes.

## Changes

### `Dockerfile.validation`

- **Install Rust toolchain** via `rustup` (minimal profile) — required for `test_cargo_check_accepts_output`. Was missing entirely.
- **Set `KOTLIN_CLASSPATH=/opt/kotlin-libs/*`** — the kotlinx-serialization jars were already downloaded but the env var wasn't set, so the test had no way to find them.

### `tests/test_generator_framework_execution.py`

- `test_kotlinc_accepts_output` now **glob-expands `KOTLIN_CLASSPATH`** before passing to `kotlinc`. Unlike `javac`, `kotlinc` does not expand classpath wildcards itself — it warned `non-existent location: /opt/kotlin-libs/*` and the `@Serializable` import never resolved.

### `scripts/validate-in-docker.sh`

- Always invokes `docker build` (BuildKit cache makes it a no-op when nothing changed; `--rebuild` adds `--no-cache`). Previously you had to remember to pass `--rebuild` after editing `Dockerfile.validation` or the pre-commit hook would run against a stale image.

## Verification

Inside the rebuilt image:

```
tests/test_generator_framework_execution.py ...............    [100%]
============================= 15 passed in 21.28s ==============================
```

Pydantic / SQLAlchemy / Dataclasses / TypedDict / Pathway / JSON Schema (×2) / GraphQL / Avro / Protobuf / Rust / Zod / Kotlin / Jackson — all 15 framework-execution tests **actually run**, no skips.

## Test plan

- [x] Local: `scripts/validate-in-docker.sh` → 30 passed, 0 skipped (no skips after this PR)
- [x] CI's `External Compiler Validation` should also see zero skips for these generators

🤖 Generated with [Claude Code](https://claude.com/claude-code)