### PR TITLE
chore: bump version to 0.3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "schema-gen"
-version = "0.3.9"
+version = "0.3.10"
 description = "Universal schema converter - define once, generate everywhere"
 readme = "README.md"
 authors = [

--- a/src/schema_gen/__init__.py
+++ b/src/schema_gen/__init__.py
@@ -17,5 +17,5 @@ Example:
 from .core.config import Config
 from .core.schema import Field, Schema
 
-__version__ = "0.3.9"
+__version__ = "0.3.10"
 __all__ = ["Schema", "Field", "Config", "__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -2296,7 +2296,7 @@ wheels = [
 
 [[package]]
 name = "schema-gen"
-version = "0.3.9"
+version = "0.3.10"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Carries the changes merged via #109 (closes #108).

## Summary

- `feat(core)`: per-field wire-name `alias=` for Pydantic / Rust / JSON Schema / Zod (closes #108).
- Pydantic auto-enables `populate_by_name=True` only when at least one field uses an alias.
- Rust serde rename suppression compares against serde's effective default wire key (not the Rust identifier), so raw-identifier aliases lower correctly.
- Schema-level validation rejects alias collisions.

Built and published to Nexus via `build.sh`; `uv.lock` synced.

## Test plan

- [x] `./build.sh` — version bump + 491 tests pass + wheel/sdist built + Nexus upload OK
- [x] `uv run pre-commit run --all-files` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)