### PR TITLE
fix(pydantic): emit serialize_by_alias=True in ConfigDict when any field has alias= (#111)

### DIFF
--- a/docs/generators/pydantic.md
+++ b/docs/generators/pydantic.md
@@ -23,6 +23,7 @@ keys are silently ignored so typos don't spuriously enable
 | `strict`               | `bool`      | Enable strict-mode coercion rules. |
 | `str_strip_whitespace` | `bool`      | Auto-strip whitespace from all string fields. |
 | `populate_by_name`     | `bool`      | Allow populating fields by their declared name even when an alias is set. |
+| `serialize_by_alias`   | `bool`      | Serialize using alias keys by default (affects `model_dump()` / `model_dump_json()`). Auto-enabled when any field has `alias=`. |
 
 String values are properly `repr()`-escaped, so `extra="forbid"` emits
 `extra='forbid'` in the generated `ConfigDict(...)`.
@@ -74,9 +75,11 @@ class StrategyDef:
 ```
 
 The Pydantic generator emits `Field(alias="_coalesce_reasoning")` and
-auto-enables `populate_by_name=True` on the model so consumers can
-construct/parse using either name. `populate_by_name` is added on
-demand — schemas without any aliased fields don't acquire it.
+auto-enables both `populate_by_name=True` (so the model accepts either
+the alias or the Python attribute name on input) and `serialize_by_alias=True`
+(so `model_dump()` / `model_dump_json()` return alias keys by default,
+without needing `by_alias=True` at every call site — issue #111).
+Both flags are added on demand — schemas without any aliased fields don't acquire them.
 
 ## `PydanticMeta` on schemas
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "schema-gen"
-version = "0.3.10"
+version = "0.3.11"
 description = "Universal schema converter - define once, generate everywhere"
 readme = "README.md"
 authors = [

--- a/src/schema_gen/__init__.py
+++ b/src/schema_gen/__init__.py
@@ -17,5 +17,5 @@ Example:
 from .core.config import Config
 from .core.schema import Field, Schema
 
-__version__ = "0.3.10"
+__version__ = "0.3.11"
 __all__ = ["Schema", "Field", "Config", "__version__"]

--- a/src/schema_gen/generators/pydantic_generator.py
+++ b/src/schema_gen/generators/pydantic_generator.py
@@ -68,24 +68,23 @@ class PydanticGenerator(BaseGenerator):
     def _get_model_config_line(self, force_populate_by_name: bool = False) -> str:
         """Build the ``model_config = ConfigDict(...)`` line.
 
-        Honors keys in ``Config.pydantic`` such as ``extra``,
-        ``validate_assignment``, ``frozen``, ``strict``,
-        ``str_strip_whitespace`` and ``populate_by_name``. When no
-        Pydantic config is supplied, falls back to the historical
+        Honors keys in ``Config.pydantic`` (see ``_SUPPORTED_PYDANTIC_CONFIG_KEYS``).
+        When no Pydantic config is supplied, falls back to the historical
         hardcoded output (``from_attributes=True`` only) so existing
         callers see no change.
 
         ``force_populate_by_name`` is set when at least one field on the
-        model carries an ``alias=`` (issue #108) — Pydantic v2 requires
-        ``populate_by_name=True`` for the model to accept input under
-        the Python attribute name as well as the alias.
+        model carries an ``alias=`` (issue #108/#111) — the generator
+        auto-emits BOTH ``populate_by_name=True`` (so the Python attribute
+        name is accepted on input) AND ``serialize_by_alias=True`` (so
+        ``model_dump()`` / ``model_dump_json()`` default to alias wire keys).
 
-        Precedence: ``Config.pydantic["populate_by_name"]`` wins when
-        explicitly set. If the user opts the model out
-        (``populate_by_name=False``) while alias-bearing fields are
-        present, the generator logs a warning so the contract conflict
-        is visible — Pydantic will then reject input under the Python
-        name even though the schema author set ``alias=``.
+        Precedence: explicit ``Config.pydantic`` values win over the
+        auto-emitted defaults. If the user sets ``populate_by_name=False``
+        while alias-bearing fields are present, the generator logs a warning
+        — Pydantic will then reject input under the Python attribute name.
+        Setting ``serialize_by_alias=False`` explicitly suppresses alias-key
+        serialization without a warning (the user opted out deliberately).
         """
         cfg_items: list[str] = ["from_attributes=True"]
         pyd_cfg: dict[str, Any] = {}
@@ -452,9 +451,9 @@ class PydanticGenerator(BaseGenerator):
         if field.description:
             field_params.append(f"description={json.dumps(field.description)}")
 
-        # Wire-format key override (issue #108). Lowers to ``alias=...``
-        # on the Pydantic Field plus ``populate_by_name=True`` on the
-        # model (handled by ``_get_model_config_line``).
+        # Wire-format key override (issue #108/#111). Lowers to ``alias=...``
+        # on the Pydantic Field plus ``populate_by_name=True`` and
+        # ``serialize_by_alias=True`` on the model (via ``_get_model_config_line``).
         if getattr(field, "alias", None):
             field_params.append(f"alias={json.dumps(field.alias)}")
 
@@ -611,9 +610,10 @@ class PydanticGenerator(BaseGenerator):
 
         1. Any field has a database relationship (the historical reason
            ``from_attributes=True`` was needed),
-        2. Any field carries an ``alias=`` (issue #108) — the model
-           must opt into ``populate_by_name=True`` so the Python
-           attribute name remains accepted on input, OR
+        2. Any field carries an ``alias=`` (issue #108/#111) — the model
+           auto-enables ``populate_by_name=True`` and ``serialize_by_alias=True``
+           so the Python attribute name is accepted on input and ``model_dump()``
+           defaults to alias wire keys, OR
         3. ``Config.pydantic`` contains at least one key that this
            generator actually honors (see ``_SUPPORTED_PYDANTIC_CONFIG_KEYS``).
 

--- a/src/schema_gen/generators/pydantic_generator.py
+++ b/src/schema_gen/generators/pydantic_generator.py
@@ -25,6 +25,7 @@ _SUPPORTED_PYDANTIC_CONFIG_KEYS: tuple[str, ...] = (
     "strict",
     "str_strip_whitespace",
     "populate_by_name",
+    "serialize_by_alias",
 )
 
 
@@ -111,6 +112,8 @@ class PydanticGenerator(BaseGenerator):
                     "will reject input under the Python attribute name; only "
                     "the alias key will be accepted."
                 )
+            if "serialize_by_alias" not in emitted_keys:
+                cfg_items.append("serialize_by_alias=True")
         return f"    model_config = ConfigDict({', '.join(cfg_items)})"
 
     @property

--- a/tests/test_field_alias.py
+++ b/tests/test_field_alias.py
@@ -119,9 +119,10 @@ def test_pydantic_no_alias_no_populate_by_name_drift():
     # Bare schema → no ConfigDict at all (current pre-#108 behavior).
     assert "model_config = ConfigDict" not in out
     assert "populate_by_name" not in out
+    assert "serialize_by_alias" not in out
 
     # Schema that DOES emit a config block (relationship triggers it)
-    # must still not carry populate_by_name when no alias is present.
+    # must still not carry populate_by_name or serialize_by_alias when no alias is present.
     @Schema
     class Related:
         owner_id: int = Field(relationship="many_to_one", foreign_key="users.id")
@@ -129,6 +130,7 @@ def test_pydantic_no_alias_no_populate_by_name_drift():
     out2 = PydanticGenerator().generate_file(SchemaParser().parse_schema(Related))
     assert "model_config = ConfigDict" in out2
     assert "populate_by_name" not in out2
+    assert "serialize_by_alias" not in out2
 
 
 def test_pydantic_warns_when_config_disables_populate_by_name(caplog):

--- a/tests/test_field_alias.py
+++ b/tests/test_field_alias.py
@@ -93,6 +93,7 @@ def test_pydantic_emits_field_alias_and_populate_by_name():
     out = PydanticGenerator().generate_file(_build_alias_schema())
     assert 'alias="_coalesce_reasoning"' in out
     assert "populate_by_name=True" in out
+    assert "serialize_by_alias=True" in out
     # The rename must NOT clobber the unrelated field.
     assert re.search(r"\bname:\s*str\s*=\s*Field\(", out)
     # ``from_attributes=True`` must still be present (pre-existing behavior).
@@ -184,9 +185,9 @@ def test_pydantic_alias_works_in_generated_module(tmp_path, monkeypatch):
     )
     assert inst2.coalesce_reasoning == "via_python"
 
-    # Round-trip serialization uses the alias by default? No — Pydantic
-    # serializes by Python name unless ``by_alias=True`` is requested.
-    # Confirm both modes work.
+    # With serialize_by_alias=True in ConfigDict, model_dump() defaults to
+    # alias keys. Explicit by_alias=False overrides back to Python names.
+    assert inst.model_dump()["_coalesce_reasoning"] == "because"
     assert inst.model_dump(by_alias=True)["_coalesce_reasoning"] == "because"
     assert "coalesce_reasoning" in inst.model_dump(by_alias=False)
 

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[options]
+exclude-newer = "2026-04-26T10:45:06Z"
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
## Summary

- When any `@Schema` field has `alias=`, the Pydantic generator now emits `serialize_by_alias=True` alongside the existing `populate_by_name=True` in the generated `ConfigDict`
- This means `model_dump()` / `model_dump_json()` default to alias wire keys without callers needing to pass `by_alias=True` at every call site
- `serialize_by_alias` can be overridden via `Config.pydantic["serialize_by_alias"]` (it joins `_SUPPORTED_PYDANTIC_CONFIG_KEYS`)
- Schemas without any aliased fields are unaffected

## Root cause

Issue #111: `model_dump()` was returning Python attribute names even when `alias=` was set, because `ConfigDict` lacked `serialize_by_alias=True`. The only workaround was `model_dump(by_alias=True)` at every call site — blocked by the staleness pre-commit hook on generated files in downstream repos (tradingcore#572).

## Changes

- `pydantic_generator.py`: add `serialize_by_alias` to `_SUPPORTED_PYDANTIC_CONFIG_KEYS`; emit `serialize_by_alias=True` in `_get_model_config_line` when `force_populate_by_name=True`
- `pydantic_generator.py`: update docstrings and inline comments to reflect both auto-emitted keys
- `docs/generators/pydantic.md`: add `serialize_by_alias` row to config-key table; update field-aliases section
- `tests/test_field_alias.py`: assert `serialize_by_alias=True` is present when aliases exist; assert it is absent when no aliases are present; add `model_dump()` (no arg) assertion in smoke test

## Test plan

- [ ] `uv run pytest tests/test_field_alias.py tests/test_pydantic_config.py` — 48 passed
- [ ] `uv run pytest` — 495 passed, 4 skipped
- [ ] All pre-commit hooks pass (both commits)

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)