### PR TITLE
feat(unions): cross-language discriminated-union round-trip (Zod, JSON Schema, serde fix)

### DIFF
--- a/docs/generators/rust.md
+++ b/docs/generators/rust.md
@@ -319,6 +319,48 @@ pub struct Order {
 }
 ```
 
+### Wire format: internally tagged
+
+The enum uses serde's **internally-tagged** representation
+(`#[serde(tag = "...")]`): the discriminator key lives *inside* the
+variant object alongside its other fields, e.g.
+`{"type": "market", "qty": 5}`. This matches exactly what Pydantic v2's
+`Annotated[Union[...], Field(discriminator=...)]` and Zod's
+`z.discriminatedUnion(...)` emit, so a payload round-trips
+byte-for-byte (key order aside) across Python ↔ Rust ↔ TypeScript.
+This interop is enforced by
+`tests/test_discriminated_union_roundtrip.py`, which feeds one canonical
+JSON payload through every generated artefact and asserts identical
+re-serialization.
+
+### Variant tag field is serde-skipped
+
+serde's internally-tagged enum **owns** the discriminator key on the
+wire: it consumes the tag on deserialize and re-emits it from the enum
+variant identity on serialize. A variant struct must therefore not
+(de)serialize its own `Literal` tag field, or serde double-emits the key
+(serialize) or fails with "missing field" (deserialize).
+
+schema-gen handles this automatically: when a struct is used as a
+discriminated-union variant, its tag field is emitted as
+`#[serde(skip)]` and the struct gains a `Default` derive (a skipped
+field is reconstructed via `Default::default()` on deserialize):
+
+```rust
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default)]
+pub struct MarketLeg {
+    #[serde(skip)]
+    pub r#type: String,
+    pub qty: i64,
+}
+```
+
+This detection requires whole-set knowledge (the variant struct is a
+*different* schema from the one declaring the union), so it is applied
+during a parser post-pass over all schemas — i.e. via the CLI / full
+`generate_all()` run, which is how generation always happens in
+practice.
+
 Plain `Union[A, B]` without a discriminator is emitted as
 `serde_json::Value` and logs a warning. See the [Known limitations](#known-limitations)
 section.
@@ -412,6 +454,16 @@ the top of the referencing file. No manual wiring is needed.
   `HashMap<String, serde_json::Value>` — the value type is not yet
   threaded through USR. Tracked with
   [jagatsingh/schema-gen#19](https://github.com/jagatsingh/schema-gen/issues/19).
-- **Pydantic / Zod discriminated-union emit** is not yet implemented;
-  only the Rust side honors `Field(discriminator=...)` today. Tracked
-  in [jagatsingh/schema-gen#20](https://github.com/jagatsingh/schema-gen/issues/20).
+- **Discriminated-union emit is wired across all four targets**: Rust
+  (internally-tagged enum), Pydantic v2
+  (`Annotated[Union[...], Field(discriminator=...)]`), Zod
+  (`z.discriminatedUnion(...)`), and JSON Schema (`oneOf` + an
+  OpenAPI-style `discriminator` object). Cross-language round-trip is
+  covered by `tests/test_discriminated_union_roundtrip.py`.
+- **`Default`-derive requirement for variants**: because the tag field is
+  `#[serde(skip)]`, a discriminated-union variant struct derives
+  `Default`, which requires every *other* field on that variant to be
+  `Default` too. A variant carrying a non-`Default` field type (e.g. a
+  nested struct that itself lacks `Default`) will not compile. Keep
+  variant payloads to scalar / `Option` / `Default`-able fields, or add a
+  `Default` derive to the nested type.

--- a/docs/schema-format.md
+++ b/docs/schema-format.md
@@ -236,9 +236,20 @@ Field(
 Use `Annotated[Union[...], Field(discriminator="<tag>")]` to mark a
 field as a discriminated union. Every union member must be a `@Schema`
 class with a `Literal["..."]` tag field matching the discriminator name.
-The Rust generator lowers this to a `#[serde(tag = "...")]` tagged enum.
-Pydantic and Zod discriminated-union lowering is planned — see
-[docs/generators/rust.md](generators/rust.md#discriminated-unions).
+All four targets lower this to their idiomatic discriminated-union
+construct on one shared **internally-tagged** wire format
+(`{"<tag>": "...", ...}`):
+
+| Target      | Lowering |
+|-------------|----------|
+| Rust        | `#[serde(tag = "<tag>")]` enum (internally tagged) |
+| Pydantic v2 | `Annotated[Union[...], Field(discriminator="<tag>")]` |
+| Zod         | `z.discriminatedUnion("<tag>", [...])` |
+| JSON Schema | `oneOf` + `{"discriminator": {"propertyName": "<tag>"}}` |
+
+See [docs/generators/rust.md](generators/rust.md#discriminated-unions)
+for the Rust wire-format details (including why variant tag fields are
+serde-skipped) and the cross-language round-trip test.
 
 ```python
 from typing import Annotated, Literal, Union

--- a/src/schema_gen/core/usr.py
+++ b/src/schema_gen/core/usr.py
@@ -158,6 +158,17 @@ class USRField:
     # by the parser when ``discriminator`` is set and validated.
     union_tag_values: list[str] = field(default_factory=list)
 
+    # Set True by the parser's post-pass when THIS field is the
+    # discriminator (Literal tag) of a struct that is used as a variant of
+    # some internally-tagged discriminated union. serde's internally-tagged
+    # enum owns the tag key on the wire (it is consumed on deserialize and
+    # re-emitted on serialize from the enum variant identity), so the Rust
+    # generator must NOT emit this field as a normally (de)serialized field
+    # — it emits ``#[serde(skip)]`` and requires the struct to derive
+    # ``Default``. Pydantic / Zod / JSON Schema keep the field as-is because
+    # their wire format carries the tag inside the variant object.
+    is_discriminator_tag: bool = False
+
     # Field tags for grouped constant emission
     tags: list[str] = field(default_factory=list)
 

--- a/src/schema_gen/generators/jsonschema_generator.py
+++ b/src/schema_gen/generators/jsonschema_generator.py
@@ -312,7 +312,18 @@ class JsonSchemaGenerator(BaseGenerator):
                     union_schema = {}
                     self._add_type_info(union_type, union_schema)
                     union_schemas.append(union_schema)
-                field_schema["anyOf"] = union_schemas
+                # Discriminated union (#18): emit oneOf + an OpenAPI-style
+                # discriminator object so the variants are mutually
+                # exclusive and consumers can dispatch on the tag field.
+                # This matches the serde internally-tagged Rust enum and
+                # the Zod z.discriminatedUnion on the wire.
+                if field.discriminator and field.union_tag_values:
+                    field_schema["oneOf"] = union_schemas
+                    field_schema["discriminator"] = {
+                        "propertyName": field.discriminator
+                    }
+                else:
+                    field_schema["anyOf"] = union_schemas
 
         elif field.type == FieldType.LITERAL:
             if field.literal_values:

--- a/src/schema_gen/generators/rust_generator.py
+++ b/src/schema_gen/generators/rust_generator.py
@@ -631,6 +631,15 @@ class RustGenerator(BaseGenerator):
                 if extra not in derives:
                     derives.append(extra)
 
+        # Discriminated-union variant structs carry a ``#[serde(skip)]`` tag
+        # field (#18 round-trip fix). A skipped field is reconstructed via
+        # ``Default::default()`` on deserialize, so the struct must derive
+        # ``Default``. Added here (not in _DEFAULT_STRUCT_DERIVES) so only
+        # the affected structs pick it up.
+        if any(getattr(f, "is_discriminator_tag", False) for f in fields):
+            if "Default" not in derives:
+                derives.append("Default")
+
         lines: list[str] = []
         if schema.description and is_base:
             for doc_line in schema.description.strip().splitlines():
@@ -750,6 +759,21 @@ class RustGenerator(BaseGenerator):
         serde_attrs: list[str] = []
         name = field.name
         emitted_name = _rust_field_ident(name)
+
+        # Discriminated-union tag field (#18 round-trip fix). When this
+        # struct is a variant of a serde internally-tagged enum, serde owns
+        # the discriminator key on the wire: it is consumed on deserialize
+        # and re-emitted from the enum variant identity on serialize. The
+        # variant struct must therefore NOT (de)serialize the field itself,
+        # or serde double-emits / fails on the missing key. ``skip`` drops
+        # it from both directions; the value is reconstructed via the
+        # struct's ``Default`` derive on deserialize. This branch is
+        # mutually exclusive with rename/default/alias handling below.
+        if getattr(field, "is_discriminator_tag", False):
+            out.append("#[serde(skip)]")
+            out.append(f"pub {emitted_name}: {rust_type},")
+            out.append("")
+            return out
 
         # Per-field alias (issue #108) wins over the name-based wire-name
         # heuristic. The user wrote ``Field(alias="...")`` precisely to

--- a/src/schema_gen/generators/zod_generator.py
+++ b/src/schema_gen/generators/zod_generator.py
@@ -450,6 +450,15 @@ class ZodGenerator(BaseGenerator):
 
         elif field.type == FieldType.UNION:
             if field.union_types:
+                # Discriminated union (#18): when the field carries a
+                # discriminator and the parser resolved a tag value per
+                # variant, emit z.discriminatedUnion so the wire format
+                # matches the serde internally-tagged Rust enum and the
+                # Pydantic Annotated[Union, Field(discriminator=...)].
+                if field.discriminator and field.union_tag_values:
+                    member_types = [self._get_zod_type(ut) for ut in field.union_types]
+                    members = ", ".join(member_types)
+                    return f'z.discriminatedUnion("{field.discriminator}", [{members}])'
                 union_types = [self._get_zod_type(ut) for ut in field.union_types]
                 return f"z.union([{', '.join(union_types)}])"
             else:

--- a/src/schema_gen/parsers/schema_parser.py
+++ b/src/schema_gen/parsers/schema_parser.py
@@ -326,10 +326,39 @@ class SchemaParser:
         if all_errors:
             raise ValueError("Schema validation failed:\n" + "\n".join(all_errors))
 
+        # Discriminated-union post-pass (#18 round-trip fix). A struct used
+        # as a variant of a serde internally-tagged enum must NOT serialize
+        # its own discriminator field — serde owns the tag key. Mark the
+        # discriminator (Literal) field on every variant schema so the Rust
+        # generator emits ``#[serde(skip)]`` + ``Default``. This requires
+        # cross-schema knowledge, hence the post-pass over the full set.
+        self._mark_discriminator_tag_fields(usr_schemas)
+
         # Sort by schema name so downstream generators emit files and
         # index entries in a stable, environment-independent order.
         usr_schemas.sort(key=lambda s: s.name)
         return usr_schemas
+
+    @staticmethod
+    def _mark_discriminator_tag_fields(usr_schemas: list[USRSchema]) -> None:
+        """Flag each variant schema's discriminator field as serde-owned.
+
+        For every field that is a discriminated union (``discriminator`` set
+        and ``union_tag_values`` resolved), find each variant schema by name
+        and set ``is_discriminator_tag=True`` on its matching tag field.
+        """
+        by_name = {s.name: s for s in usr_schemas}
+        for schema in usr_schemas:
+            for fld in schema.fields:
+                if not (fld.discriminator and fld.union_tag_values):
+                    continue
+                for variant in fld.union_types:
+                    variant_schema = by_name.get(variant.nested_schema or "")
+                    if variant_schema is None:
+                        continue
+                    tag_field = variant_schema.get_field(fld.discriminator)
+                    if tag_field is not None:
+                        tag_field.is_discriminator_tag = True
 
     def parse_schema_by_name(self, schema_name: str) -> USRSchema:
         """Parse a specific schema by name

--- a/tests/test_discriminated_union_roundtrip.py
+++ b/tests/test_discriminated_union_roundtrip.py
@@ -1,0 +1,381 @@
+"""Cross-language round-trip tests for discriminated (tagged) unions.
+
+A discriminated union — ``Annotated[Union[A, B], Field(discriminator="...")]``
+on the Python side — must serialize to ONE canonical wire format and round-trip
+identically across every target schema-gen emits:
+
+* **Pydantic v2** — ``Annotated[Union[...], Field(discriminator=...)]``
+* **Rust / serde** — internally-tagged enum (``#[serde(tag = "...")]``)
+* **Zod** — ``z.discriminatedUnion("...", [...])``
+* **JSON Schema** — ``oneOf`` + an OpenAPI-style ``discriminator`` object
+
+The chosen wire representation is **internally tagged**: the discriminator key
+lives *inside* the variant object alongside its other fields, e.g.::
+
+    {"instrument_type": "futures", "contract": "ESZ5"}
+
+serde's internally-tagged enum, Pydantic's discriminated union, and Zod's
+discriminated union all agree on exactly this shape, which is why it is the
+representation schema-gen targets (rather than externally- or adjacently-tagged).
+
+This is the highest-leverage union test: a single canonical JSON payload is
+fed through every generated artefact and each is asserted to produce a
+byte-identical (key-sorted) re-serialization, proving genuine interop rather
+than four independent "looks plausible" string checks.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Annotated, Literal
+
+import pytest
+
+from schema_gen import Field, Schema
+from schema_gen.core.config import Config
+from schema_gen.core.generator import SchemaGenerationEngine
+from schema_gen.core.schema import SchemaRegistry
+from schema_gen.generators.jsonschema_generator import JsonSchemaGenerator
+from schema_gen.generators.rust_generator import RustGenerator
+from schema_gen.generators.zod_generator import ZodGenerator
+from schema_gen.parsers.schema_parser import SchemaParser
+
+# -----------------------------------------------------------------------
+# Schema fixtures — module-level for forward-reference resolution
+# -----------------------------------------------------------------------
+
+
+@Schema
+class RTFuturesSpec:
+    """Futures variant — discriminator value "futures"."""
+
+    instrument_type: Literal["futures"]
+    contract: str
+
+
+@Schema
+class RTOptionsSpec:
+    """Options variant — discriminator value "options"."""
+
+    instrument_type: Literal["options"]
+    strike: float
+
+
+@Schema
+class RTTradeOrder:
+    """trade_spec-style discriminated union keyed on instrument_type."""
+
+    spec: Annotated[
+        RTFuturesSpec | RTOptionsSpec, Field(discriminator="instrument_type")
+    ]
+
+
+# Two canonical wire payloads — one per variant. Key order is irrelevant on
+# the wire (objects are unordered); we compare structurally after json.loads.
+# NOTE: ``strike`` is deliberately non-integral (5000.25, not 5000.0).
+# JavaScript has a single Number type, so JSON.stringify renders 5000.0 as
+# "5000" — a numeric-formatting artifact unrelated to union dispatch that
+# would otherwise make the Zod structural comparison spuriously fail. A
+# non-integral value round-trips identically across Python/Rust/Zod.
+WIRE_FUTURES = {"spec": {"instrument_type": "futures", "contract": "ESZ5"}}
+WIRE_OPTIONS = {"spec": {"instrument_type": "options", "strike": 5000.25}}
+WIRE_PAYLOADS = [WIRE_FUTURES, WIRE_OPTIONS]
+
+
+def _canonical(obj: dict) -> str:
+    """Deterministic, structural JSON encoding for cross-language equality."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+@pytest.fixture(autouse=True)
+def _register_schemas():
+    SchemaRegistry._schemas.clear()
+    for cls in (RTFuturesSpec, RTOptionsSpec, RTTradeOrder):
+        SchemaRegistry.register(cls)
+    yield
+    SchemaRegistry._schemas.clear()
+
+
+# -----------------------------------------------------------------------
+# Generator-output shape (fast, no toolchain required)
+# -----------------------------------------------------------------------
+
+
+class TestDiscriminatedUnionShape:
+    """Each generator emits the discriminated-union construct, not a blob."""
+
+    def test_rust_internally_tagged_enum(self):
+        usr = SchemaParser().parse_schema(RTTradeOrder)
+        out = RustGenerator().generate_file(usr)
+        assert '#[serde(tag = "instrument_type")]' in out
+        assert "pub enum RTTradeOrderSpec {" in out
+        assert "Futures(RTFuturesSpec)" in out
+        assert "Options(RTOptionsSpec)" in out
+        assert "pub spec: RTTradeOrderSpec," in out
+        # Must NOT degrade to an untyped blob.
+        assert "serde_json::Value" not in out.split("pub spec:")[1].split(",")[0]
+
+    def test_zod_discriminated_union(self):
+        usr = SchemaParser().parse_schema(RTTradeOrder)
+        out = ZodGenerator().generate_file(usr)
+        assert (
+            'z.discriminatedUnion("instrument_type", '
+            "[RTFuturesSpecSchema, RTOptionsSpecSchema])"
+        ) in out
+        assert "z.union([" not in out  # plain union would lose discrimination
+
+    def test_jsonschema_oneof_plus_discriminator(self):
+        usr = SchemaParser().parse_schema(RTTradeOrder)
+        doc = json.loads(JsonSchemaGenerator().generate_file(usr))
+        spec = doc["$defs"]["RTTradeOrder"]["properties"]["spec"]
+        assert "oneOf" in spec
+        assert "anyOf" not in spec  # mutually exclusive, not "any"
+        assert spec["discriminator"] == {"propertyName": "instrument_type"}
+        assert len(spec["oneOf"]) == 2
+
+
+# -----------------------------------------------------------------------
+# Python / Pydantic round-trip (always runs)
+# -----------------------------------------------------------------------
+
+
+class TestPydanticRoundTrip:
+    """The generated Pydantic model parses and re-emits the canonical wire."""
+
+    def _build_models(self, tmp_path: Path):
+        import importlib.util
+        import sys
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        cfg = Config(
+            input_dir=str(out_dir / "in"),
+            output_dir=str(out_dir),
+            targets=["pydantic"],
+        )
+        SchemaGenerationEngine(cfg).generate_all()
+        pydantic_dir = out_dir / "pydantic"
+
+        # Import the whole generated package so every variant model is in
+        # scope, then rebuild the union model to resolve its string
+        # forward-references (``Annotated[Union["RTFuturesSpec", ...]]``).
+        pkg_name = "_rt_pydantic_pkg"
+        pkg_spec = importlib.util.spec_from_file_location(
+            pkg_name,
+            pydantic_dir / "__init__.py",
+            submodule_search_locations=[str(pydantic_dir)],
+        )
+        pkg_mod = importlib.util.module_from_spec(pkg_spec)
+        sys.modules[pkg_name] = pkg_mod
+        self._loaded_pkg_prefix = pkg_name
+        pkg_spec.loader.exec_module(pkg_mod)
+        order_cls = pkg_mod.RTTradeOrder
+        order_cls.model_rebuild(
+            _types_namespace={
+                "RTFuturesSpec": pkg_mod.RTFuturesSpec,
+                "RTOptionsSpec": pkg_mod.RTOptionsSpec,
+            }
+        )
+        return order_cls
+
+    def teardown_method(self):
+        import sys
+
+        prefix = getattr(self, "_loaded_pkg_prefix", None)
+        if prefix:
+            for key in [k for k in sys.modules if k.startswith(prefix)]:
+                sys.modules.pop(key, None)
+
+    @pytest.mark.parametrize("wire", WIRE_PAYLOADS)
+    def test_pydantic_roundtrip(self, tmp_path: Path, wire: dict):
+        TradeOrder = self._build_models(tmp_path)
+        obj = TradeOrder.model_validate(wire)
+        emitted = json.loads(obj.model_dump_json())
+        assert _canonical(emitted) == _canonical(wire)
+
+
+# -----------------------------------------------------------------------
+# Rust round-trip — compile a tiny harness, deserialize + re-serialize
+# -----------------------------------------------------------------------
+
+_RUST_MAIN = r"""
+use generated::RTTradeOrder;
+use std::io::Read;
+
+fn main() {
+    let mut input = String::new();
+    std::io::stdin().read_to_string(&mut input).unwrap();
+    // Deserialize each line, re-serialize, print one JSON per line.
+    for line in input.lines().filter(|l| !l.trim().is_empty()) {
+        let parsed: RTTradeOrder = serde_json::from_str(line).unwrap();
+        let out = serde_json::to_string(&parsed).unwrap();
+        println!("{}", out);
+    }
+}
+"""
+
+
+@pytest.mark.skipif(not shutil.which("cargo"), reason="cargo not installed")
+def test_rust_roundtrip(tmp_path: Path):
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    cfg = Config(
+        input_dir=str(out_dir / "in"),
+        output_dir=str(out_dir),
+        targets=["rust"],
+    )
+    SchemaGenerationEngine(cfg).generate_all()
+    rust_dir = out_dir / "rust"
+
+    # Build a binary crate that depends on the generated lib as a module.
+    crate = tmp_path / "rt_crate"
+    src = crate / "src"
+    src.mkdir(parents=True)
+
+    # Re-home the generated files: lib.rs + per-schema modules under src/.
+    for rs in rust_dir.glob("*.rs"):
+        shutil.copy(rs, src / rs.name)
+    # Rename lib.rs content into a module tree the binary can import.
+    lib_src = (src / "lib.rs").read_text()
+    (src / "lib.rs").write_text(lib_src)
+    (src / "main.rs").write_text(_RUST_MAIN)
+
+    cargo_toml = (
+        "[package]\n"
+        'name = "generated"\n'
+        'version = "0.0.0"\n'
+        'edition = "2021"\n\n'
+        "[dependencies]\n"
+        'serde = { version = "1", features = ["derive"] }\n'
+        'serde_json = "1"\n'
+        'schemars = "0.8"\n\n'
+        "[[bin]]\n"
+        'name = "rt"\n'
+        'path = "src/main.rs"\n'
+    )
+    (crate / "Cargo.toml").write_text(cargo_toml)
+
+    payload = "\n".join(json.dumps(p) for p in WIRE_PAYLOADS)
+    result = subprocess.run(
+        ["cargo", "run", "--quiet", "--bin", "rt"],
+        cwd=crate,
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, (
+        f"cargo run failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+    lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    assert len(lines) == len(WIRE_PAYLOADS), f"unexpected output: {result.stdout!r}"
+    for emitted_line, wire in zip(lines, WIRE_PAYLOADS, strict=True):
+        assert _canonical(json.loads(emitted_line)) == _canonical(wire)
+
+
+# -----------------------------------------------------------------------
+# Zod round-trip — parse + re-serialize via a compiled-then-run TS harness
+# -----------------------------------------------------------------------
+
+_ZOD_HARNESS = """
+import {{ RTTradeOrderSchema }} from "./rttradeorder";
+
+const payloads = {payloads};
+const out = payloads.map((p: unknown) => RTTradeOrderSchema.parse(p));
+process.stdout.write(JSON.stringify(out));
+"""
+
+
+@pytest.mark.skipif(not shutil.which("npx"), reason="npx not installed")
+def test_zod_roundtrip(tmp_path: Path):
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    cfg = Config(
+        input_dir=str(out_dir / "in"),
+        output_dir=str(out_dir),
+        targets=["zod"],
+    )
+    SchemaGenerationEngine(cfg).generate_all()
+    zod_dir = out_dir / "zod"
+
+    (zod_dir / "harness.ts").write_text(
+        _ZOD_HARNESS.format(payloads=json.dumps(WIRE_PAYLOADS))
+    )
+
+    if (
+        subprocess.run(
+            ["npm", "init", "-y"],
+            cwd=zod_dir,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        ).returncode
+        != 0
+    ):
+        pytest.skip("npm init failed")
+
+    install = subprocess.run(
+        ["npm", "install", "zod", "typescript", "tsx"],
+        cwd=zod_dir,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if install.returncode != 0:
+        pytest.skip(f"npm install failed: {install.stderr}")
+
+    result = subprocess.run(
+        ["npx", "tsx", "harness.ts"],
+        cwd=zod_dir,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"zod harness failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+    parsed = json.loads(result.stdout)
+    assert len(parsed) == len(WIRE_PAYLOADS)
+    for emitted, wire in zip(parsed, WIRE_PAYLOADS, strict=True):
+        assert _canonical(emitted) == _canonical(wire)
+
+
+# -----------------------------------------------------------------------
+# JSON Schema validation — the canonical wire must validate against oneOf
+# -----------------------------------------------------------------------
+
+
+def test_jsonschema_validates_wire(tmp_path: Path):
+    jsonschema = pytest.importorskip("jsonschema")
+
+    usr = SchemaParser().parse_schema(RTTradeOrder)
+    fut_usr = SchemaParser().parse_schema(RTFuturesSpec)
+    opt_usr = SchemaParser().parse_schema(RTOptionsSpec)
+
+    order_doc = json.loads(JsonSchemaGenerator().generate_file(usr))
+    fut_doc = json.loads(JsonSchemaGenerator().generate_file(fut_usr))
+    opt_doc = json.loads(JsonSchemaGenerator().generate_file(opt_usr))
+
+    # Inline the variant $defs so the spec field's $ref targets resolve
+    # without a network/file resolver.
+    spec = order_doc["$defs"]["RTTradeOrder"]["properties"]["spec"]
+    spec["oneOf"] = [
+        fut_doc["$defs"]["RTFuturesSpec"],
+        opt_doc["$defs"]["RTOptionsSpec"],
+    ]
+    schema = order_doc["$defs"]["RTTradeOrder"]
+
+    for wire in WIRE_PAYLOADS:
+        jsonschema.validate(instance=wire, schema=schema)
+
+    # A payload with an unknown discriminator must fail validation.
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance={"spec": {"instrument_type": "swaps", "x": 1}},
+            schema=schema,
+        )


### PR DESCRIPTION
## Summary

Closes the discriminated (tagged) union gap so all four targets emit their idiomatic discriminated-union construct on **one shared internally-tagged wire format**, and fixes a latent serde round-trip bug that no prior test caught.

Motivating consumers (tradingcore): `trade_spec = FuturesSpec | OptionsSpec` keyed on `instrument_type`, and `OmsCommand.payload` keyed on `command_type` — both currently ship as `dict[str, Any]` JSONB blobs on the Rust side. This makes them proper tagged enums.

## What was already present (prior commits)

- USR carries `discriminator` + parser-resolved `union_tag_values`.
- **Rust**: internally-tagged enum `#[serde(tag = "...")]` with per-variant `#[serde(rename)]`.
- **Pydantic v2**: `Annotated[Union[...], Field(discriminator=...)]`.

## Gaps closed in this PR

| Target | Before | After |
|--------|--------|-------|
| **Zod** | `z.union([...])` (loses discrimination) | `z.discriminatedUnion("<tag>", [...])` |
| **JSON Schema** | `anyOf` (undiscriminated) | `oneOf` + `{"discriminator": {"propertyName": "<tag>"}}` |

## The serde round-trip bug (the load-bearing fix)

serde's internally-tagged enum **owns** the discriminator key on the wire: it consumes the tag on deserialize and re-emits it from the variant identity on serialize. A variant struct that declared its `Literal` tag as a required `String` therefore:

- **failed to deserialize** with `missing field "<tag>"`, and
- **double-emitted** the key on serialize.

No existing test caught this — they only asserted *string presence* in the generated code, never exercised real serde (de)serialization. I verified the failure empirically with a standalone cargo project, then fixed it:

1. A parser post-pass (`_mark_discriminator_tag_fields`, run inside `parse_all_schemas`) flags each variant schema's discriminator field with `is_discriminator_tag=True`. This needs whole-set knowledge — the variant is a *different* schema from the one declaring the union — so it can't be done per-file.
2. The Rust generator emits that field as `#[serde(skip)]` and adds a `Default` derive to the struct, so the value is reconstructed via `Default::default()` on deserialize.

Pydantic / Zod / JSON Schema are unaffected — their wire format legitimately carries the tag inside the variant object.

## Chosen tag representation: internally tagged

`{"instrument_type": "futures", "contract": "ESZ5"}` — the tag lives inside the variant object. This is the single shape that serde's `#[serde(tag)]`, Pydantic v2's discriminated union, and Zod's `discriminatedUnion` **all** agree on, confirmed by the round-trip test. Adjacently-tagged would have required custom serde container attributes and diverged from Pydantic's default.

## Tests

`tests/test_discriminated_union_roundtrip.py` — feeds one canonical JSON payload (one per variant) through **every generated artefact** and asserts byte-identical (key-sorted) re-serialization:

- **Pydantic**: real `model_validate` + `model_dump_json`.
- **Rust**: generates the crate, compiles a tiny harness, `cargo run` deserialize→serialize.
- **Zod**: generates `.ts`, runs `RTTradeOrderSchema.parse(...)` via `tsx`.
- **JSON Schema**: validates the wire payload against `oneOf`, and asserts an unknown discriminator is rejected.

8 new tests, all green. **Full suite: 512 passed / 5 skipped** (was 504), no regressions. Ruff lint + format clean. `cargo check` / `tsc --strict` e2e tests still pass.

## Implemented vs deferred

- **Implemented**: internally-tagged round-trip across Python ↔ Rust ↔ Zod ↔ JSON Schema, plus the serde variant-tag fix. This is the full Phase-1b slice.
- **Deferred / documented limitation**: because the variant struct gains a `Default` derive (needed for the skipped tag field), a variant carrying a **non-`Default` field type** (e.g. a nested struct lacking `Default`) won't compile. Documented in `docs/generators/rust.md` → Known limitations. A follow-up could emit a `#[serde(default = "...")]`-style per-field helper instead of a whole-struct `Default`, but the current slice is correct for scalar/Option/Default-able variant payloads (the common case).

## Docs

Updated `docs/generators/rust.md` (wire-format + serde-skip explanation, refreshed Known limitations) and `docs/schema-format.md` (all-four-targets table, removed the stale "Pydantic/Zod not yet implemented" note).

## Review note

Local Stage-1b review (code-reviewer pass) found no correctness bugs. Stage-1a Codex CLI was **rate-limited** (usage limit, resets Jun 4) so could not run this round — flagging for the maintainer; the GitHub-side Codex connector review should still cover Stage 2.

> Do not merge — schema-gen's release process is owned by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)