### PR TITLE
fix(rust-union): drop struct-level Default on union variants (0.3.21)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "schema-gen"
-version = "0.3.19"
+version = "0.3.21"
 description = "Universal schema converter - define once, generate everywhere"
 readme = "README.md"
 authors = [

--- a/src/schema_gen/__init__.py
+++ b/src/schema_gen/__init__.py
@@ -17,5 +17,5 @@ Example:
 from .core.config import Config
 from .core.schema import Field, Schema
 
-__version__ = "0.3.19"
+__version__ = "0.3.21"
 __all__ = ["Schema", "Field", "Config", "__version__"]

--- a/src/schema_gen/generators/rust_generator.py
+++ b/src/schema_gen/generators/rust_generator.py
@@ -632,13 +632,17 @@ class RustGenerator(BaseGenerator):
                     derives.append(extra)
 
         # Discriminated-union variant structs carry a ``#[serde(skip)]`` tag
-        # field (#18 round-trip fix). A skipped field is reconstructed via
-        # ``Default::default()`` on deserialize, so the struct must derive
-        # ``Default``. Added here (not in _DEFAULT_STRUCT_DERIVES) so only
-        # the affected structs pick it up.
-        if any(getattr(f, "is_discriminator_tag", False) for f in fields):
-            if "Default" not in derives:
-                derives.append("Default")
+        # field (#18 round-trip fix). serde reconstructs a skipped field on
+        # deserialize via ``<FieldType as Default>::default()`` — i.e. it
+        # needs only the *tag field's type* (always ``String`` here) to be
+        # ``Default``, NOT the whole struct. Deriving struct-level ``Default``
+        # was over-reach: it happens to be satisfiable when every non-tag
+        # field is itself ``Default`` (e.g. all-``String`` variants like
+        # EventBufferSource*/StateDef*), but breaks the moment a variant
+        # carries a required non-``Default`` nested field (e.g.
+        # ``OptionsSpec { expiry: ExpirySelector, .. }``). The skip already
+        # provides everything round-trip needs, so no struct-level ``Default``
+        # is emitted. See jagatsingh/tradingcore T1b regression.
 
         lines: list[str] = []
         if schema.description and is_base:

--- a/tests/test_rust_generator.py
+++ b/tests/test_rust_generator.py
@@ -1124,6 +1124,43 @@ class _PlainUnionOrder:
     leg: _CeLeg | _PeLeg
 
 
+@Schema
+class _NonDefaultNested:
+    """A nested struct with NO ``Default`` (required enum field)."""
+
+    mode: Literal["x"]  # a required field; the struct is not Default-able
+    note: str
+
+
+@Schema
+class _VariantWithNonDefaultField:
+    """Union variant carrying a required non-Default nested struct.
+
+    The discriminator-tag round-trip fix marks ``kind`` ``#[serde(skip)]``;
+    serde reconstructs it via ``String::default()`` (only the tag field's
+    type must be ``Default``). Deriving struct-level ``Default`` here would
+    NOT compile because ``nested`` is non-Default — the regression this
+    fixture guards against.
+    """
+
+    kind: Literal["with_nested"]
+    nested: _NonDefaultNested
+
+
+@Schema
+class _PlainVariant:
+    kind: Literal["plain"]
+    value: int
+
+
+@Schema
+class _UnionWithNonDefaultVariant:
+    spec: Annotated[
+        _VariantWithNonDefaultField | _PlainVariant,
+        Field(discriminator="kind"),
+    ]
+
+
 class TestRustDiscriminatedUnion:
     """Annotated[Union[A, B], Field(discriminator="...")] → serde tagged enum."""
 
@@ -1139,6 +1176,10 @@ class TestRustDiscriminatedUnion:
             _DiscriminatedOrder,
             _DiscriminatedThreeWay,
             _PlainUnionOrder,
+            _NonDefaultNested,
+            _VariantWithNonDefaultField,
+            _PlainVariant,
+            _UnionWithNonDefaultVariant,
         ):
             SchemaRegistry.register(cls)
 
@@ -1178,6 +1219,34 @@ class TestRustDiscriminatedUnion:
             out = RustGenerator().generate_file(usr)
         assert "pub leg: serde_json::Value," in out
         assert any("union field 'leg'" in rec.message for rec in caplog.records)
+
+    def test_variant_with_non_default_field_skips_tag_without_struct_default(self):
+        """A union variant carrying a required non-Default nested struct must
+        still emit ``#[serde(skip)]`` on the tag field but must NOT derive
+        struct-level ``Default`` — the skip only needs the tag field's type
+        (String) to be Default, and a whole-struct Default would fail to
+        compile against the non-Default nested field.
+        """
+        # parse_all_schemas() runs the post-pass that marks discriminator-tag
+        # fields (is_discriminator_tag) across the full registry — the singular
+        # parse_schema() does not, so the skip would not appear.
+        schemas = SchemaParser().parse_all_schemas()
+        gen = RustGenerator()
+        variant_usr = next(
+            s for s in schemas if s.name == "_VariantWithNonDefaultField"
+        )
+        out = gen.generate_file(variant_usr)
+        # The tag field is serde-skipped (round-trip fix preserved).
+        assert "#[serde(skip)]" in out
+        assert "pub kind: String," in out
+        # But the struct must NOT carry a Default derive (would not compile).
+        derive_line = next(
+            line for line in out.splitlines() if line.strip().startswith("#[derive(")
+        )
+        assert "Default" not in derive_line, (
+            f"struct-level Default leaked onto a variant with a non-Default "
+            f"nested field: {derive_line!r}"
+        )
 
 
 # ------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -2299,7 +2299,7 @@ wheels = [
 
 [[package]]
 name = "schema-gen"
-version = "0.3.19"
+version = "0.3.21"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Clean fix for the union-variant Default over-reach (the #[serde(skip)] tag needs only String:Default, not the whole struct — broke OptionsSpec-style variants with required non-Default nested fields). +regression test. **Supersedes #125** (which conflicted on release files). 0.3.21 released to Nexus; 0.3.20 was published without this fix (superseded — consider yanking from Nexus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)