### PR TITLE
chore(release): schema-gen 0.3.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "schema-gen"
-version = "0.3.21"
+version = "0.3.22"
 description = "Universal schema converter - define once, generate everywhere"
 readme = "README.md"
 authors = [

--- a/src/schema_gen/__init__.py
+++ b/src/schema_gen/__init__.py
@@ -17,5 +17,5 @@ Example:
 from .core.config import Config
 from .core.schema import Field, Schema
 
-__version__ = "0.3.21"
+__version__ = "0.3.22"
 __all__ = ["Schema", "Field", "Config", "__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -2299,7 +2299,7 @@ wheels = [
 
 [[package]]
 name = "schema-gen"
-version = "0.3.21"
+version = "0.3.22"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Canonical 0.3.22 build (on Nexus) so tradingcore CI can pin it for reproducible contract regen.