### PR TITLE
security: fix Dependabot CVEs (2026-05-30)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,9 +63,11 @@ Issues = "https://github.com/jagatsingh/schema-gen/issues"
 
 # Security: minimum versions for transitive deps with CVEs
 # urllib3>=2.7.0: high CVE fix (CVE-2026-44431 cross-origin headers; CVE-2026-44432 decompression-bomb safeguard bypass)
+# idna>=3.15: CVE-2026-45409 (GHSA-65pc-fj4g-8rjx)
 [tool.uv]
 constraint-dependencies = [
     "urllib3>=2.7.0",
+    "idna>=3.15",
 ]
 
 [build-system]
@@ -93,7 +95,7 @@ dev = [
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.6.18",
     "mkdocstrings[python]>=0.30.0",
-    "pymdown-extensions>=10.16.1",
+    "pymdown-extensions>=10.21.3",
     "pytest>=8.4.2",
     "pytest-cov>=6.3.0",
     "setuptools<83",  # Pin setuptools to avoid pkg_resources deprecation warnings

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,10 @@ resolution-markers = [
 ]
 
 [manifest]
-constraints = [{ name = "urllib3", specifier = ">=2.7.0" }]
+constraints = [
+    { name = "idna", specifier = ">=3.15" },
+    { name = "urllib3", specifier = ">=2.7.0" },
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -928,11 +931,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.17"
 source = { registry = "http://localhost:5081/repository/pypi-group/simple" }
-sdist = { url = "http://localhost:5081/repository/pypi-group/packages/idna/3.11/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902" }
+sdist = { url = "http://localhost:5081/repository/pypi-group/packages/idna/3.17/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f" }
 wheels = [
-    { url = "http://localhost:5081/repository/pypi-group/packages/idna/3.11/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea" },
+    { url = "http://localhost:5081/repository/pypi-group/packages/idna/3.17/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c" },
 ]
 
 [[package]]
@@ -2003,15 +2006,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.2"
+version = "10.21.3"
 source = { registry = "http://localhost:5081/repository/pypi-group/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "http://localhost:5081/repository/pypi-group/packages/pymdown-extensions/10.21.2/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc" }
+sdist = { url = "http://localhost:5081/repository/pypi-group/packages/pymdown-extensions/10.21.3/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354" }
 wheels = [
-    { url = "http://localhost:5081/repository/pypi-group/packages/pymdown-extensions/10.21.2/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638" },
+    { url = "http://localhost:5081/repository/pypi-group/packages/pymdown-extensions/10.21.3/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6" },
 ]
 
 [[package]]
@@ -2420,7 +2423,7 @@ dev = [
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", specifier = ">=9.6.18" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.30.0" },
-    { name = "pymdown-extensions", specifier = ">=10.16.1" },
+    { name = "pymdown-extensions", specifier = ">=10.21.3" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-cov", specifier = ">=6.3.0" },
     { name = "setuptools", specifier = "<83" },


### PR DESCRIPTION
Automated weekly security maintenance.

## Fixes
- idna: <3.15 -> 3.15 (GHSA-65pc-fj4g-8rjx / CVE-2026-45409)
- pymdown-extensions: <=10.21.2 -> 10.21.3 (GHSA-62q4-447f-wv8h / CVE-2026-46338)

## Not fixed (no upstream patch yet)
- diskcache (GHSA-w8v5-vhqr-4h9v / CVE-2025-69872) — unsafe pickle deserialization, no patched version available

## Method
env -u UV_EXCLUDE_NEWER uv lock --upgrade-package idna --upgrade-package pymdown-extensions (security exception to 7-day delay)

🤖 Weekly maintenance — claude scheduled task