### PR TITLE
feat(rust): honor object-map type-override on dict[str, Any] fields (#130)

### DIFF
--- a/Dockerfile.validation
+++ b/Dockerfile.validation
@@ -6,7 +6,7 @@
 # BuildKit frontend directive on the very first line (above). Without it,
 # Docker's classic parser sees ``{`` after the heredoc on the next line and
 # errors with ``unknown instruction: {`` (https://docs.docker.com/build/dockerfile/release-notes/#14-0).
-FROM python:3.14-slim
+FROM python:3.12-slim
 
 LABEL maintainer="schema-gen"
 LABEL description="Complete validation environment with all external compilers"

--- a/docs/generators/rust.md
+++ b/docs/generators/rust.md
@@ -86,7 +86,7 @@ schemars = "0.8"
 | `time`                       | `chrono::NaiveTime`             |
 | `UUID`                       | `uuid::Uuid`                    |
 | `Decimal`                    | `rust_decimal::Decimal`         |
-| `dict[str, Any]`             | `serde_json::Value`             |
+| `dict[str, Any]`             | `serde_json::Value` (object-map override available) |
 | `dict[str, T]`               | `HashMap<String, T>`            |
 | `list[T]` / `set[T]`         | `Vec<T>`                        |
 | `tuple[A, B, ...]`           | `(A, B, ...)`                   |
@@ -206,6 +206,32 @@ ratio: float = Field(rust={"type": "f32"})
 
 Valid integer types: `i8`, `i16`, `i32`, `i64`, `i128`, `isize`, `u8`,
 `u16`, `u32`, `u64`, `u128`, `usize`. Valid float types: `f32`, `f64`.
+
+### Object-map override on `dict[str, Any]`
+
+By default a `dict[str, Any]` (or plain `dict`) lowers to
+`serde_json::Value`, which also admits non-object JSON (`null`, arrays,
+scalars). To constrain the Rust type to objects only — making non-object
+payloads unrepresentable rather than runtime-validated — apply an
+object-map override:
+
+```python
+payload: dict[str, Any] = Field(
+    rust={"type": "serde_json::Map<String, serde_json::Value>"}
+)
+```
+
+```rust
+pub payload: serde_json::Map<String, serde_json::Value>,
+```
+
+Valid object-map types: `serde_json::Map<String, serde_json::Value>`
+(object-only, no extra import) and `HashMap<String, serde_json::Value>`
+(adds `use std::collections::HashMap;`). Pass the exact string shown above;
+any other value logs a warning and falls back to `serde_json::Value`. The
+override is only consulted on `dict[str, Any]` / plain `dict` fields —
+`dict[str, T]` with a concrete value type still lowers to
+`HashMap<String, T>`.
 
 ## Enums
 
@@ -450,10 +476,10 @@ the top of the referencing file. No manual wiring is needed.
 - **Nested `Optional` inside collections** (`list[Optional[T]]`) is not
   special-cased; it lowers to `Vec<Option<T>>` only when the USR layer
   retains the `Optional` wrapper on the inner type.
-- **`dict[str, T]`** always lowers to
-  `HashMap<String, serde_json::Value>` — the value type is not yet
-  threaded through USR. Tracked with
-  [jagatsingh/schema-gen#19](https://github.com/jagatsingh/schema-gen/issues/19).
+- **`dict[str, Any]`** (object-map at the JSON level) lowers to
+  `serde_json::Value` by default; apply a
+  [`Field(rust={"type": ...})` object-map override](#object-map-override-on-dictstr-any)
+  to emit an object-only `serde_json::Map<String, serde_json::Value>`.
 - **Discriminated-union emit is wired across all four targets**: Rust
   (internally-tagged enum), Pydantic v2
   (`Annotated[Union[...], Field(discriminator=...)]`), Zod

--- a/scripts/test_all_formats.sh
+++ b/scripts/test_all_formats.sh
@@ -224,10 +224,14 @@ EOF
         (cd "$temp_ts_dir" && npm install --silent) 2>/dev/null
     fi
 
-    # Create tsconfig.json
-    echo '{"compilerOptions":{"target":"ES2020","module":"commonjs","strict":true,"esModuleInterop":true,"skipLibCheck":true,"noEmit":true}}' > "$temp_ts_dir/tsconfig.json"
+    # Create tsconfig.json. ``include`` lists the source file so a bare
+    # ``tsc`` invocation drives compilation from the project config. Passing
+    # the file on the command line instead would make TypeScript 6.0+ reject
+    # the run with TS5112 ("tsconfig.json is present but will not be loaded
+    # if files are specified on commandline").
+    echo '{"compilerOptions":{"target":"ES2020","module":"commonjs","strict":true,"esModuleInterop":true,"skipLibCheck":true,"noEmit":true},"include":["test.ts"]}' > "$temp_ts_dir/tsconfig.json"
 
-    if (cd "$temp_ts_dir" && npx tsc test.ts --noEmit); then
+    if (cd "$temp_ts_dir" && npx tsc); then
         print_success "TypeScript compilation works"
         external_passed=$((external_passed + 1))
     else

--- a/src/schema_gen/generators/rust_generator.py
+++ b/src/schema_gen/generators/rust_generator.py
@@ -112,6 +112,19 @@ _VALID_RUST_INT_TYPES = frozenset(
 # Rust built-in float types accepted by Field(rust={"type": "..."}).
 _VALID_RUST_FLOAT_TYPES = frozenset({"f32", "f64"})
 
+# Rust object-map types accepted by Field(rust={"type": "..."}) on dict
+# fields whose value type is ``Any`` (``dict[str, Any]`` / plain ``dict``).
+# Without an override these lower to ``serde_json::Value``, which also admits
+# non-object JSON (null/array/scalar). An object-map override constrains the
+# Rust type to objects only, making non-object payloads unrepresentable.
+# Exact-string match, mirroring the int/float whitelists.
+_VALID_RUST_DICT_TYPES = frozenset(
+    {
+        "serde_json::Map<String, serde_json::Value>",
+        "HashMap<String, serde_json::Value>",
+    }
+)
+
 
 def _rust_field_ident(name: str) -> str:
     """Return the Rust identifier for a field name.
@@ -898,9 +911,23 @@ class RustGenerator(BaseGenerator):
             return "Vec<serde_json::Value>"
 
         if ftype == FieldType.DICT:
-            # dict[str, Any] or plain dict -> serde_json::Value (any JSON)
+            # dict[str, Any] or plain dict -> serde_json::Value (any JSON),
+            #   unless a Field(rust={"type": ...}) object-map override is given.
             # dict[str, T] where T is a specific type -> HashMap<String, T>
             if field.inner_type is None or field.inner_type.type == FieldType.JSON:
+                if override_type:
+                    if override_type in _VALID_RUST_DICT_TYPES:
+                        if override_type.startswith("HashMap"):
+                            imports.add("HashMap")
+                        return override_type
+                    logger.warning(
+                        "Rust generator: ignoring invalid Field(rust={'type': %r}) "
+                        "on dict field '%s' (valid: %s). Falling back to "
+                        "serde_json::Value.",
+                        override_type,
+                        field.name,
+                        sorted(_VALID_RUST_DICT_TYPES),
+                    )
                 return "serde_json::Value"
             imports.add("HashMap")
             value_type = self._rust_type_for(

--- a/tests/test_e2e_compile.py
+++ b/tests/test_e2e_compile.py
@@ -120,6 +120,33 @@ class E2EEventConfig:
 # -----------------------------------------------------------------------
 
 
+def _make_object_map_schema() -> USRSchema:
+    """Object-map override (#130): dict[str, Any] → serde_json::Map.
+
+    Rust-only fixture (kept out of the @Schema registry so it doesn't flow
+    into the Zod/Pydantic/JSON-Schema e2e targets). Proves the object-map
+    override emits Rust that actually compiles under cargo.
+    """
+    return USRSchema(
+        name="E2EObjectMap",
+        fields=[
+            USRField(
+                name="payload",
+                type=FieldType.DICT,
+                python_type=dict,
+                inner_type=USRField(
+                    name="payload_value",
+                    type=FieldType.JSON,
+                    python_type=object,
+                ),
+                target_config={
+                    "rust": {"type": "serde_json::Map<String, serde_json::Value>"}
+                },
+            ),
+        ],
+    )
+
+
 def _make_tree_node_schema() -> USRSchema:
     """Direct self-reference: parent: Optional[TreeNode] → Box<T>."""
     return USRSchema(
@@ -198,10 +225,20 @@ class TestE2ECompile:
         tree_content = gen.generate_file(tree_schema)
         (rust_dir / "e2e_tree_node.rs").write_text(tree_content)
 
-        # Add TreeNode module to lib.rs
+        # Object-map override (#130): dict[str, Any] → serde_json::Map.
+        # USR-level fixture, Rust-only — write it manually like TreeNode.
+        object_map_content = gen.generate_file(_make_object_map_schema())
+        assert (
+            "pub payload: serde_json::Map<String, serde_json::Value>,"
+            in object_map_content
+        )
+        (rust_dir / "e2e_object_map.rs").write_text(object_map_content)
+
+        # Add TreeNode + ObjectMap modules to lib.rs
         lib_rs = rust_dir / "lib.rs"
         lib_content = lib_rs.read_text()
         lib_content += "pub mod e2e_tree_node;\npub use e2e_tree_node::*;\n"
+        lib_content += "pub mod e2e_object_map;\npub use e2e_object_map::*;\n"
         lib_rs.write_text(lib_content)
 
         # Add missing dependencies the generated code may reference.

--- a/tests/test_rust_generator.py
+++ b/tests/test_rust_generator.py
@@ -947,6 +947,98 @@ class TestRustWidthOverride:
 
 
 # ----------------------------------------------------------------------
+# Per-field object-map override on dict[str, Any] fields (#130)
+# ----------------------------------------------------------------------
+
+
+class TestRustDictTypeOverride:
+    """Field(rust={"type": ...}) lowers dict[str, Any] to an object-map.
+
+    Without an override ``dict[str, Any]`` lowers to ``serde_json::Value``
+    (which also admits null/array/scalar JSON). An object-map override
+    constrains the Rust type to objects only — see schema-gen#130.
+    """
+
+    def setup_method(self):
+        SchemaRegistry._schemas.clear()
+
+    def test_dict_any_serde_json_map_override(self):
+        @Schema
+        class OmsCommand:
+            payload: dict[str, Any] = Field(
+                rust={"type": "serde_json::Map<String, serde_json::Value>"}
+            )
+
+        usr = SchemaParser().parse_schema(OmsCommand)
+        out = RustGenerator().generate_file(usr)
+        assert "pub payload: serde_json::Map<String, serde_json::Value>," in out
+        assert "pub payload: serde_json::Value," not in out
+        # serde_json::Map is fully qualified — no HashMap import.
+        assert "use std::collections::HashMap;" not in out
+
+    def test_dict_any_hashmap_override_adds_import(self):
+        @Schema
+        class Bag:
+            attrs: dict[str, Any] = Field(
+                rust={"type": "HashMap<String, serde_json::Value>"}
+            )
+
+        usr = SchemaParser().parse_schema(Bag)
+        out = RustGenerator().generate_file(usr)
+        assert "pub attrs: HashMap<String, serde_json::Value>," in out
+        assert "use std::collections::HashMap;" in out
+
+    def test_optional_dict_any_override_wraps_in_option(self):
+        @Schema
+        class OptCommand:
+            payload: dict[str, Any] | None = Field(
+                default=None,
+                rust={"type": "serde_json::Map<String, serde_json::Value>"},
+            )
+
+        usr = SchemaParser().parse_schema(OptCommand)
+        out = RustGenerator().generate_file(usr)
+        assert "pub payload: Option<serde_json::Map<String, serde_json::Value>>," in out
+
+    def test_dict_any_invalid_override_falls_back_with_warning(self, caplog):
+        @Schema
+        class BadMap:
+            data: dict[str, Any] = Field(rust={"type": "BTreeMap<String, Value>"})
+
+        usr = SchemaParser().parse_schema(BadMap)
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            out = RustGenerator().generate_file(usr)
+        assert "pub data: serde_json::Value," in out
+        assert any("BTreeMap<String, Value>" in rec.message for rec in caplog.records)
+
+    def test_dict_any_no_override_still_serde_json_value(self):
+        @Schema
+        class Plain:
+            settings: dict[str, Any]
+
+        usr = SchemaParser().parse_schema(Plain)
+        out = RustGenerator().generate_file(usr)
+        assert "pub settings: serde_json::Value," in out
+
+    def test_concrete_value_dict_ignores_override(self):
+        """The override only applies to dict[str, Any] / plain dict — a
+        concrete-value dict still threads its value type into HashMap<…>."""
+
+        @Schema
+        class Scores:
+            values: dict[str, int] = Field(
+                rust={"type": "HashMap<String, serde_json::Value>"}
+            )
+
+        usr = SchemaParser().parse_schema(Scores)
+        out = RustGenerator().generate_file(usr)
+        assert "pub values: HashMap<String, i64>," in out
+        assert "serde_json::Value" not in out
+
+
+# ----------------------------------------------------------------------
 # Enum-level SerdeMeta support
 # ----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Closes #130.

A `dict[str, Any]` source field always lowered to Rust `serde_json::Value`, which also admits non-object JSON (`null`/array/scalar). The `Field(rust={"type": ...})` override was honored only for INTEGER/FLOAT fields — the DICT branch short-circuited to `serde_json::Value` before consulting it.

This adds `_VALID_RUST_DICT_TYPES` and consults the override in the DICT/`Any` branch, mirroring the existing int/float whitelist + warn-and-fallback pattern:

| `Field(rust={"type": ...})` | Emitted Rust | Import |
|---|---|---|
| `serde_json::Map<String, serde_json::Value>` | object-only map | none |
| `HashMap<String, serde_json::Value>` | general map | `use std::collections::HashMap;` |
| invalid / unset | `serde_json::Value` (default) + warning if invalid | — |

A concrete-value `dict[str, T]` still threads its value type into `HashMap<String, T>` — the override only applies to the `Any`/plain-dict short-circuit. Default (no-override) output is unchanged, so existing golden outputs are unaffected.

This lets a wire type be **object-constrained at the Rust type level** (invalid states unrepresentable) instead of runtime-validated — unblocking the deferred Part 2 of tradingcore #847 (`OmsCommand.payload` → `Map<String, Value>`).

Also refreshes a stale `rust.md` known-limitation that claimed `dict[str, T]` drops its value type (the generator threads it through correctly).

## Validation infra (required to land the generator change through CI)
- **`Dockerfile.validation`**: `python:3.14-slim` → `python:3.12-slim`. The package `requires-python` is `>=3.12,<3.13`, so the 3.14 image could not install the package at all (and lacked a prebuilt `pyarrow` wheel / `cmake`). The image's own label already declared 3.12.
- **`scripts/test_all_formats.sh`**: TypeScript 6.0 rejects `tsc <file> --noEmit` when a `tsconfig.json` is present (TS5112). Now drives compilation via tsconfig `include` + bare `npx tsc` — version-agnostic, semantically identical (still `strict` + `noEmit` over `test.ts`).

## Testing
- 6 new unit tests: object-map override, HashMap override + import, optional wrapping (`Option<…>`), invalid-fallback + warning, no-override default, concrete-value-dict-untouched.
- A Rust-only USR fixture compiled under real `cargo check` in `test_e2e_compile.py`.
- Full suite: **519 passed, 5 skipped**. Docker comprehensive validation (`validate-in-docker.sh`): **31 passed** in-container. Local `test_all_formats.sh`: **100%** (core 3/3, external 3/3).

## Review
- Pre-push local `code-reviewer` subagent: **approved (READY TO PUSH)**.
- `codex review` CLI was rate-limited locally (resets Jun 4); relying on the GitHub-side Codex connector for Stage 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)