### PR TITLE
feat(unions): top-level / standalone discriminated unions via register_union (#131)

### DIFF
--- a/Dockerfile.validation
+++ b/Dockerfile.validation
@@ -6,7 +6,7 @@
 # BuildKit frontend directive on the very first line (above). Without it,
 # Docker's classic parser sees ``{`` after the heredoc on the next line and
 # errors with ``unknown instruction: {`` (https://docs.docker.com/build/dockerfile/release-notes/#14-0).
-FROM python:3.14-slim
+FROM python:3.12-slim
 
 LABEL maintainer="schema-gen"
 LABEL description="Complete validation environment with all external compilers"

--- a/docs/generators/rust.md
+++ b/docs/generators/rust.md
@@ -365,6 +365,48 @@ Plain `Union[A, B]` without a discriminator is emitted as
 `serde_json::Value` and logs a warning. See the [Known limitations](#known-limitations)
 section.
 
+### Standalone / top-level discriminated unions
+
+When a discriminated union is a wire type in its own right — not a field
+on a `@Schema` — declare it with `register_union` so it emits a
+**top-level** tagged enum named after the alias (rather than nothing):
+
+```python
+from typing import Annotated, Union
+from schema_gen import Field, register_union
+
+FuturesOrderRequest = register_union(
+    "FuturesOrderRequest",
+    Annotated[
+        Union[FuturesMarketOrder, FuturesLimitOrder],
+        Field(discriminator="order_type"),
+    ],
+)
+```
+
+```rust
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "order_type")]
+pub enum FuturesOrderRequest {
+    #[serde(rename = "market")]
+    Market(FuturesMarketOrder),
+    #[serde(rename = "limit")]
+    Limit(FuturesLimitOrder),
+}
+```
+
+`register_union` returns the alias unchanged, so the symbol stays usable
+as a normal Python type hint. The same registration drives the Pydantic
+(`Annotated[Union, Field(discriminator=...)]` alias), Zod
+(`z.discriminatedUnion`), and JSON Schema (`oneOf` + discriminator)
+generators — the four targets that can express a tagged union. Targets
+that cannot (`sqlalchemy`, `dataclasses`, `typeddict`, `avro`,
+`protobuf`, `graphql`, `kotlin`, `jackson`, `pathway`) skip the union
+(with a warning) rather than emit a misleading struct. The variant
+structs and the serde-skip tag-field handling are identical to the
+field-level case above. Cross-language round-trip is covered by
+`tests/test_standalone_union.py`.
+
 ## Variants
 
 `class Variants:` blocks still work: each variant is emitted as a separate

--- a/docs/schema-format.md
+++ b/docs/schema-format.md
@@ -274,6 +274,35 @@ class Order:
     leg: Annotated[Union[MarketLeg, LimitLeg], Field(discriminator="type")]
 ```
 
+#### Standalone (top-level) discriminated unions
+
+When the union is a wire type in its own right — not a field on a
+`@Schema` — register it with `register_union(name, annotated_union)` so it
+generates a **named** tagged union of its own (rather than nothing):
+
+```python
+from typing import Annotated, Union
+from schema_gen import Field, register_union
+
+FuturesOrderRequest = register_union(
+    "FuturesOrderRequest",
+    Annotated[
+        Union[MarketLeg, LimitLeg],
+        Field(discriminator="type"),
+    ],
+)
+```
+
+The variant contract is identical to the field-level form (each member a
+`@Schema` with a `Literal[...]` tag). It lowers to the same four
+constructs in the table above — a top-level Rust enum, a Pydantic
+`Annotated[Union, Field(discriminator=...)]` alias, a Zod
+`z.discriminatedUnion` export, and a JSON Schema `oneOf` + discriminator
+document — each named after the alias. `register_union` returns the alias
+unchanged so it remains usable as a Python type hint. Targets without a
+tagged-union construct (SQLAlchemy, dataclasses, TypedDict, Avro,
+Protobuf, GraphQL, Kotlin, Jackson, Pathway) skip it with a warning.
+
 ### Field Tags
 
 Use `tags` to annotate fields with metadata that schema-gen uses to emit

--- a/src/schema_gen/__init__.py
+++ b/src/schema_gen/__init__.py
@@ -15,7 +15,7 @@ Example:
 """
 
 from .core.config import Config
-from .core.schema import Field, Schema
+from .core.schema import Field, Schema, register_union
 
 __version__ = "0.3.22"
-__all__ = ["Schema", "Field", "Config", "__version__"]
+__all__ = ["Schema", "Field", "Config", "register_union", "__version__"]

--- a/src/schema_gen/core/generator.py
+++ b/src/schema_gen/core/generator.py
@@ -141,6 +141,21 @@ class SchemaGenerationEngine:
         target_dir = output_dir / target
         target_dir.mkdir(parents=True, exist_ok=True)
 
+        # Standalone discriminated unions (#131) only emit for generators
+        # that can express a tagged union. For the rest, skip them rather
+        # than emit a misleading struct with one self-named field. The
+        # filtered list feeds extra files, per-schema emission, and the
+        # index so nothing references a type that was never written.
+        if not generator.supports_root_union:
+            skipped = [s for s in schemas if s.is_root_union]
+            if skipped:
+                schemas = [s for s in schemas if not s.is_root_union]
+                names = ", ".join(s.name for s in skipped)
+                print(
+                    f"  ⚠ {target}: skipping standalone discriminated "
+                    f"union(s) not supported by this target: {names}"
+                )
+
         print(f"\nGenerating {target} models...")
 
         # 1. Write extra files (e.g. _base.py for SQLAlchemy)

--- a/src/schema_gen/core/schema.py
+++ b/src/schema_gen/core/schema.py
@@ -188,11 +188,23 @@ class SchemaRegistry:
     """Global registry of all schema definitions"""
 
     _schemas: dict[str, type] = {}
+    # Standalone / top-level discriminated unions (#131), keyed by name.
+    # Each value is the ``Annotated[Union[...], Field(discriminator=...)]``
+    # alias passed to :func:`register_union`. Kept separate from
+    # ``_schemas`` because a union is not a struct-bearing @Schema class.
+    _unions: dict[str, Any] = {}
 
     @classmethod
     def register(cls, schema_class: type) -> type:
         """Register a schema class"""
-        cls._schemas[schema_class.__name__] = schema_class
+        name = schema_class.__name__
+        if name in cls._unions:
+            raise ValueError(
+                f"name '{name}' is already registered as a standalone "
+                f"discriminated union (register_union); names must be unique "
+                f"across @Schema classes and unions"
+            )
+        cls._schemas[name] = schema_class
         return schema_class
 
     @classmethod
@@ -204,6 +216,21 @@ class SchemaRegistry:
     def get_all_schemas(cls) -> dict[str, type]:
         """Get all registered schemas"""
         return cls._schemas.copy()
+
+    @classmethod
+    def register_union(cls, name: str, annotated_union: Any) -> None:
+        """Register a standalone discriminated union by name (#131)."""
+        if name in cls._schemas:
+            raise ValueError(
+                f"name '{name}' is already registered as a @Schema class; "
+                f"names must be unique across @Schema classes and unions"
+            )
+        cls._unions[name] = annotated_union
+
+    @classmethod
+    def get_all_unions(cls) -> dict[str, Any]:
+        """Get all registered standalone discriminated unions"""
+        return cls._unions.copy()
 
 
 def Schema(cls: type) -> type:
@@ -263,6 +290,44 @@ def Schema(cls: type) -> type:
             cls._custom_code[target] = _extract_meta_attributes(meta_class)
 
     return cls
+
+
+def register_union(name: str, annotated_union: Any) -> Any:
+    """Register a top-level / standalone discriminated union (#131).
+
+    Use this when a discriminated union is a wire type in its own right —
+    not a field on a ``@Schema`` class — so the generators emit a real
+    tagged union (Rust internally-tagged enum, Zod ``z.discriminatedUnion``,
+    Pydantic ``Annotated[Union, Field(discriminator=...)]``, JSON Schema
+    ``oneOf`` + discriminator) named ``name`` rather than nothing.
+
+    Each union variant must be a registered ``@Schema`` class carrying a
+    ``Literal[...]`` discriminator field — exactly the same contract as a
+    field-level discriminated union.
+
+    Usage::
+
+        from typing import Annotated, Union
+        from schema_gen import Field, register_union
+
+        FuturesOrderRequest = register_union(
+            "FuturesOrderRequest",
+            Annotated[
+                Union[FuturesMarketOrder, FuturesLimitOrder],
+                Field(discriminator="order_type"),
+            ],
+        )
+
+    Args:
+        name: The emitted type name (the alias name).
+        annotated_union: An ``Annotated[Union[...], Field(discriminator=...)]``.
+
+    Returns:
+        ``annotated_union`` unchanged, so the symbol stays usable as a normal
+        Python type hint.
+    """
+    SchemaRegistry.register_union(name, annotated_union)
+    return annotated_union
 
 
 def _extract_meta_attributes(meta_class) -> dict:

--- a/src/schema_gen/core/usr.py
+++ b/src/schema_gen/core/usr.py
@@ -296,6 +296,23 @@ class USRSchema:
     # Schema-level metadata
     metadata: dict[str, Any] = field(default_factory=dict)
 
+    # Standalone / top-level discriminated union (#131). When True this
+    # schema is NOT a struct but a tagged-union *alias*: it has exactly one
+    # field (``fields[0]``) carrying ``discriminator`` + ``union_types`` +
+    # ``union_tag_values``, and generators emit a standalone tagged enum /
+    # discriminated union named ``self.name`` (Rust enum, Zod
+    # ``z.discriminatedUnion``, Pydantic ``Annotated[Union, Field(
+    # discriminator=...)]``, JSON Schema ``oneOf`` + discriminator) instead
+    # of a struct. See ``register_union`` in ``core/schema.py``.
+    is_root_union: bool = False
+
+    @property
+    def root_union_field(self) -> "USRField | None":
+        """The single union field for a root-union schema, else ``None``."""
+        if self.is_root_union and self.fields:
+            return self.fields[0]
+        return None
+
     def get_field(self, name: str) -> USRField | None:
         """Get a field by name"""
         return next((f for f in self.fields if f.name == name), None)

--- a/src/schema_gen/generators/base.py
+++ b/src/schema_gen/generators/base.py
@@ -52,6 +52,14 @@ class BaseGenerator(ABC):
     #: ``index.ts``. Defaults to ``__init__.py`` for Python targets.
     index_filename: str = "__init__.py"
 
+    #: Whether this generator emits a standalone discriminated union
+    #: registered via ``register_union`` (#131) as a first-class tagged
+    #: union. Generators that can't express a tagged union opt out (the
+    #: default) and the engine skips root-union schemas for them, rather
+    #: than emitting a misleading struct with a single self-named field.
+    #: Set True on the Rust, Pydantic, Zod, and JSON Schema generators.
+    supports_root_union: bool = False
+
     def get_schema_filename(self, schema: USRSchema) -> str:
         """Return the output filename for a given schema.
 

--- a/src/schema_gen/generators/jsonschema_generator.py
+++ b/src/schema_gen/generators/jsonschema_generator.py
@@ -23,6 +23,8 @@ _SUPPORTED_JSONSCHEMA_CONFIG_KEYS: frozenset[str] = frozenset(
 class JsonSchemaGenerator(BaseGenerator):
     """Generates JSON Schema definitions from USR schemas"""
 
+    supports_root_union = True  # #131: emits oneOf + discriminator
+
     def __init__(
         self,
         base_url: str = _DEFAULT_BASE_URL,
@@ -136,6 +138,33 @@ class JsonSchemaGenerator(BaseGenerator):
         js_cfg = self._js_cfg()
         schema_uri = js_cfg.get("schema_uri", _DEFAULT_SCHEMA_URI)
         base_url = self._get_base_url(schema)
+
+        # Standalone discriminated union (#131): emit a top-level oneOf +
+        # OpenAPI-style discriminator document. Variants $ref their own
+        # files (they are not local $defs of this union document).
+        if schema.is_root_union and schema.root_union_field is not None:
+            f = schema.root_union_field
+            self._current_defs = {schema.name}
+            try:
+                one_of = []
+                for ut in f.union_types:
+                    variant_schema: dict[str, Any] = {}
+                    self._add_type_info(ut, variant_schema)
+                    one_of.append(variant_schema)
+            finally:
+                self._current_defs = set()
+            union_doc: dict[str, Any] = {
+                "$schema": schema_uri,
+                "$id": f"{base_url}/{schema.name.lower()}.json",
+                "title": schema.name,
+                "description": (
+                    f"Auto-generated discriminated-union JSON Schema for {schema.name}"
+                ),
+                "oneOf": one_of,
+                "discriminator": {"propertyName": f.discriminator},
+            }
+            return json.dumps(union_doc, indent=2)
+
         json_schema: dict[str, Any] = {
             "$schema": schema_uri,
             "$id": f"{base_url}/{schema.name.lower()}.json",

--- a/src/schema_gen/generators/pydantic_generator.py
+++ b/src/schema_gen/generators/pydantic_generator.py
@@ -56,6 +56,8 @@ def _format_class_docstring(docstring: str, indent: str = "    ") -> list[str]:
 class PydanticGenerator(BaseGenerator):
     """Generates Pydantic models from USR schemas"""
 
+    supports_root_union = True  # #131: emits Annotated[Union, Field(discriminator)]
+
     def __init__(self, config: Config | None = None) -> None:
         super().__init__(config=config)
         self.template = Template(self._get_template())
@@ -238,6 +240,45 @@ class PydanticGenerator(BaseGenerator):
 
         return "\n".join(lines) + "\n"
 
+    def _generate_root_union_file(self, schema: USRSchema) -> str:
+        """Emit a module-level discriminated-union alias file (#131)."""
+        f = schema.root_union_field
+        variant_names = [
+            v.nested_schema or getattr(v.python_type, "__name__", None)
+            for v in f.union_types
+        ]
+        lines = [
+            '"""',
+            "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY",
+            f"Generated from: {schema.name}",
+            "Generator: schema-gen Pydantic generator",
+            "",
+            "To regenerate this file, run:",
+            "    schema-gen generate --target pydantic",
+            "",
+            "Changes to this file will be overwritten.",
+            '"""',
+            "",
+            "from typing import Annotated, Union",
+            "",
+            "from pydantic import Field",
+            "",
+        ]
+        # Import each variant class directly so the alias references real
+        # classes (no forward-ref resolution needed).
+        for variant in variant_names:
+            lines.append(f"from .{variant.lower()}_models import {variant}")
+        lines.append("")
+        lines.append("")
+        union_expr = ", ".join(variant_names)
+        lines.append(
+            f"{schema.name} = Annotated[\n"
+            f"    Union[{union_expr}],\n"
+            f'    Field(discriminator="{f.discriminator}"),\n'
+            f"]"
+        )
+        return "\n".join(lines) + "\n"
+
     def generate_model(self, schema: USRSchema, variant: str | None = None) -> str:
         """Generate a Pydantic model for a schema variant
 
@@ -315,6 +356,15 @@ class PydanticGenerator(BaseGenerator):
         Returns:
             Complete file content with all models
         """
+        # Standalone discriminated union (#131): emit a module-level
+        # ``Annotated[Union[...], Field(discriminator=...)]`` alias. Unlike a
+        # field-level union (which uses string forward-refs resolved via
+        # ``model_rebuild``), a standalone alias has no owning model, so the
+        # variant classes are imported for real and referenced directly —
+        # making the alias usable with ``TypeAdapter`` out of the box.
+        if schema.is_root_union and schema.root_union_field is not None:
+            return self._generate_root_union_file(schema)
+
         # Collect all imports needed
         all_imports = {"pydantic"}
         all_fields = []

--- a/src/schema_gen/generators/rust_generator.py
+++ b/src/schema_gen/generators/rust_generator.py
@@ -235,6 +235,7 @@ class RustGenerator(BaseGenerator):
     """
 
     index_filename = "lib.rs"
+    supports_root_union = True  # #131: emits a serde internally-tagged enum
 
     # Keys honored from ``Config.rust``. Any other key triggers a warning.
     _SUPPORTED_RUST_CONFIG_KEYS: frozenset[str] = frozenset(
@@ -398,6 +399,29 @@ class RustGenerator(BaseGenerator):
         # (POC finding C2). Collected before struct emission so the header
         # can render the correct ``use`` lines.
         external_schema_refs = _collect_external_schema_refs(schema)
+
+        # Standalone discriminated union (#131): emit a top-level serde
+        # internally-tagged enum named after the alias, then return. No
+        # struct/variant emission — the variant structs live in their own
+        # files and are pulled in via the external-ref ``use`` lines.
+        if schema.is_root_union and schema.root_union_field is not None:
+            f = schema.root_union_field
+            enum_body = self._generate_discriminated_union_enum(
+                helper_name=schema.name,
+                discriminator=f.discriminator,
+                variants=f.union_types,
+                tag_values=f.union_tag_values,
+                json_schema_derive=json_schema_derive,
+                imports=imports,
+            )
+            header = self._generate_header(
+                schema=schema,
+                imports=imports,
+                custom_code=custom_code,
+                json_schema_derive=json_schema_derive,
+                external_schema_refs=external_schema_refs,
+            )
+            return header + enum_body + "\n"
 
         # Schema-level rename_all (from SerdeMeta) — if set and valid, it
         # applies uniformly across both the struct and every emitted enum

--- a/src/schema_gen/generators/zod_generator.py
+++ b/src/schema_gen/generators/zod_generator.py
@@ -91,6 +91,7 @@ class ZodGenerator(BaseGenerator):
     """Generates Zod schemas (TypeScript/JavaScript) from USR schemas"""
 
     index_filename = "index.ts"
+    supports_root_union = True  # #131: emits z.discriminatedUnion
 
     def __init__(self, config: Config | None = None) -> None:
         super().__init__(config=config)
@@ -261,6 +262,27 @@ class ZodGenerator(BaseGenerator):
         # ``import { OtherSchema } from './other';`` lines at the top of
         # the generated file (Copilot POC finding C4).
         external_refs = _collect_external_schema_refs(schema)
+
+        # Standalone discriminated union (#131): emit a top-level
+        # ``z.discriminatedUnion`` const (+ inferred type) named after the
+        # alias. The variant ``…Schema`` imports come from external_refs.
+        if schema.is_root_union and schema.root_union_field is not None:
+            f = schema.root_union_field
+            members = ", ".join(self._get_zod_type(ut) for ut in f.union_types)
+            union_const = (
+                f"export const {schema.name}Schema = "
+                f'z.discriminatedUnion("{f.discriminator}", [{members}]);'
+            )
+            union_type = (
+                f"export type {schema.name} = z.infer<typeof {schema.name}Schema>;"
+            )
+            return self._generate_complete_file(
+                schema.name,
+                [union_const],
+                [union_type],
+                schema.enums,
+                external_refs=external_refs,
+            )
 
         all_schemas = []
         all_types = []

--- a/src/schema_gen/parsers/schema_parser.py
+++ b/src/schema_gen/parsers/schema_parser.py
@@ -6,7 +6,7 @@ import re
 import warnings
 from enum import Enum
 
-from ..core.schema import SchemaRegistry, _extract_meta_attributes
+from ..core.schema import Field, SchemaRegistry, _extract_meta_attributes
 from ..core.usr import FieldType, TypeMapper, USREnum, USRField, USRSchema
 
 # Mapping from target name to the inner meta class name on Enum/Schema
@@ -305,11 +305,56 @@ class SchemaParser:
             tags.append(tag)
         return tags
 
+    def parse_union(self, name: str, annotated_union) -> USRSchema:
+        """Convert a standalone discriminated union to a root-union USRSchema.
+
+        Reuses the field-level discriminated-union machinery: the
+        ``Annotated[Union[...], Field(discriminator=...)]`` alias is turned
+        into a single USRField (carrying ``discriminator`` + ``union_types``),
+        the tag values are resolved per variant, and the result is wrapped in
+        a USRSchema flagged ``is_root_union``. See ``register_union`` (#131).
+
+        Args:
+            name: The emitted type name.
+            annotated_union: ``Annotated[Union[...], Field(discriminator=...)]``.
+
+        Returns:
+            A root-union USRSchema with exactly one field.
+
+        Raises:
+            ValueError: If the alias is not a discriminated union or its
+                variants do not satisfy the discriminator contract.
+        """
+        union_field = self.type_mapper.create_usr_field_from_python(
+            name=name,
+            python_type=annotated_union,
+            field_info=Field(),
+        )
+        if not union_field.union_types:
+            raise ValueError(
+                f"register_union('{name}', ...): expected "
+                f"Annotated[Union[...], Field(discriminator=...)], "
+                f"got a non-union type"
+            )
+        if not union_field.discriminator:
+            raise ValueError(
+                f"register_union('{name}', ...): the Union must be annotated "
+                f"with Field(discriminator='<tag>') — none found"
+            )
+        try:
+            union_field.union_tag_values = self._resolve_discriminator_tags(union_field)
+        except ValueError as exc:
+            raise ValueError(
+                f"Union '{name}': discriminator resolution failed — {exc}"
+            ) from exc
+        return USRSchema(name=name, fields=[union_field], is_root_union=True)
+
     def parse_all_schemas(self) -> list[USRSchema]:
         """Parse all registered schemas to USR format
 
         Returns:
-            List of USRSchema objects for all registered schemas
+            List of USRSchema objects for all registered schemas and
+            standalone discriminated unions.
 
         Raises:
             ValueError: If any schema has validation errors
@@ -320,6 +365,13 @@ class SchemaParser:
             try:
                 usr_schema = self.parse_schema(schema_class)
                 usr_schemas.append(usr_schema)
+            except ValueError as e:
+                all_errors.append(str(e))
+
+        # Standalone discriminated unions (#131).
+        for union_name, annotated_union in SchemaRegistry.get_all_unions().items():
+            try:
+                usr_schemas.append(self.parse_union(union_name, annotated_union))
             except ValueError as e:
                 all_errors.append(str(e))
 

--- a/src/schema_gen/registry/index.py
+++ b/src/schema_gen/registry/index.py
@@ -48,6 +48,26 @@ def build_registry_index(
 
     for schema in sorted(schemas, key=lambda s: s.name):
         domain = _detect_domain(schema, config)
+
+        # Standalone discriminated union (#131): render as a union entry
+        # (discriminator + variant list) rather than a struct with one
+        # self-named field.
+        if schema.is_root_union and schema.root_union_field:
+            f = schema.root_union_field
+            variants = [
+                ut.nested_schema or getattr(ut.python_type, "__name__", "")
+                for ut in f.union_types
+            ]
+            types_index[schema.name] = {
+                "domain": domain,
+                "kind": "discriminated_union",
+                "description": schema.description or "",
+                "discriminator": f.discriminator,
+                "variants": sorted(variants),
+                "nested_types": sorted(variants),
+            }
+            continue
+
         enums_referenced: list[str] = []
         nested_types: list[str] = []
         fields_index: dict[str, dict[str, Any]] = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Shared pytest fixtures for the schema-gen test suite."""
+
+import pytest
+
+from schema_gen.core.schema import SchemaRegistry
+
+
+@pytest.fixture(autouse=True)
+def _clear_standalone_unions():
+    """Clear the standalone-union registry between tests (#131).
+
+    ``register_union`` writes to a process-global ``SchemaRegistry._unions``
+    that ``parse_all_schemas`` reads. Most tests clear ``_schemas`` in their
+    own ``setup_method`` but predate ``_unions``, so a union registered by
+    one test would otherwise leak into every later test that calls
+    ``parse_all_schemas``. Clearing after each test keeps suites isolated
+    regardless of run order.
+    """
+    yield
+    SchemaRegistry._unions.clear()

--- a/tests/test_standalone_union.py
+++ b/tests/test_standalone_union.py
@@ -1,0 +1,420 @@
+"""Tests for top-level / standalone discriminated unions (#131).
+
+``register_union(name, Annotated[Union[...], Field(discriminator=...)])``
+declares a discriminated union that is a wire type in its own right — not a
+field on a ``@Schema`` — so the generators emit a real tagged union named
+``name`` (Rust internally-tagged enum, Zod ``z.discriminatedUnion``, Pydantic
+``Annotated[Union, Field(discriminator=...)]``, JSON Schema ``oneOf`` +
+discriminator) instead of nothing.
+
+Generators that can't express a tagged union opt out via
+``supports_root_union = False`` and the engine skips the union for them
+rather than emitting a misleading struct.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Annotated, Literal
+
+import pytest
+
+from schema_gen import Field, Schema, register_union
+from schema_gen.core.config import Config
+from schema_gen.core.generator import SchemaGenerationEngine
+from schema_gen.core.schema import SchemaRegistry
+from schema_gen.generators.jsonschema_generator import JsonSchemaGenerator
+from schema_gen.generators.pydantic_generator import PydanticGenerator
+from schema_gen.generators.rust_generator import RustGenerator
+from schema_gen.generators.zod_generator import ZodGenerator
+from schema_gen.parsers.schema_parser import SchemaParser
+
+# -----------------------------------------------------------------------
+# Fixtures — module-level for forward-reference resolution
+# -----------------------------------------------------------------------
+
+
+@Schema
+class SUFuturesMarketOrder:
+    """Market order — discriminator value "market"."""
+
+    order_type: Literal["market"]
+    qty: int
+
+
+@Schema
+class SUFuturesLimitOrder:
+    """Limit order — discriminator value "limit"."""
+
+    order_type: Literal["limit"]
+    qty: int
+    limit_price: float
+
+
+# The standalone union alias under test.
+SUFuturesOrderRequest = Annotated[
+    SUFuturesMarketOrder | SUFuturesLimitOrder,
+    Field(discriminator="order_type"),
+]
+
+WIRE_PAYLOADS = [
+    {"order_type": "market", "qty": 1},
+    {"order_type": "limit", "qty": 2, "limit_price": 3.5},
+]
+
+
+def _canonical(obj) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+def _register_fixtures() -> None:
+    """(Re-)register the fixture schemas + union into the global registry."""
+    SchemaRegistry._schemas.clear()
+    SchemaRegistry._unions.clear()
+    SchemaRegistry.register(SUFuturesMarketOrder)
+    SchemaRegistry.register(SUFuturesLimitOrder)
+    register_union("SUFuturesOrderRequest", SUFuturesOrderRequest)
+
+
+# -----------------------------------------------------------------------
+# Parser / foundation
+# -----------------------------------------------------------------------
+
+
+class TestRootUnionParsing:
+    def setup_method(self):
+        _register_fixtures()
+
+    def test_parse_all_includes_root_union(self):
+        schemas = {s.name: s for s in SchemaParser().parse_all_schemas()}
+        assert "SUFuturesOrderRequest" in schemas
+        ru = schemas["SUFuturesOrderRequest"]
+        assert ru.is_root_union is True
+        f = ru.root_union_field
+        assert f is not None
+        assert f.discriminator == "order_type"
+        assert [v.nested_schema for v in f.union_types] == [
+            "SUFuturesMarketOrder",
+            "SUFuturesLimitOrder",
+        ]
+        assert f.union_tag_values == ["market", "limit"]
+
+    def test_variant_tag_fields_marked_skip(self):
+        # The variant structs' discriminator field must be flagged so serde
+        # emits #[serde(skip)] (the enum owns the tag on the wire).
+        schemas = {s.name: s for s in SchemaParser().parse_all_schemas()}
+        for variant in ("SUFuturesMarketOrder", "SUFuturesLimitOrder"):
+            tag_field = schemas[variant].get_field("order_type")
+            assert tag_field is not None
+            assert tag_field.is_discriminator_tag is True
+
+    def test_non_union_rejected(self):
+        SchemaRegistry._schemas.clear()
+        SchemaRegistry._unions.clear()
+        SchemaRegistry.register(SUFuturesMarketOrder)
+        register_union("Bad", SUFuturesMarketOrder)  # not a Union
+        with pytest.raises(ValueError, match="non-union type"):
+            SchemaParser().parse_all_schemas()
+
+    def test_union_without_discriminator_rejected(self):
+        SchemaRegistry._schemas.clear()
+        SchemaRegistry._unions.clear()
+        SchemaRegistry.register(SUFuturesMarketOrder)
+        SchemaRegistry.register(SUFuturesLimitOrder)
+        register_union(
+            "Bad", SUFuturesMarketOrder | SUFuturesLimitOrder
+        )  # no Field(discriminator=...)
+        with pytest.raises(ValueError, match="discriminator"):
+            SchemaParser().parse_all_schemas()
+
+    def test_union_name_colliding_with_schema_rejected(self):
+        SchemaRegistry._schemas.clear()
+        SchemaRegistry._unions.clear()
+        SchemaRegistry.register(SUFuturesMarketOrder)
+        with pytest.raises(ValueError, match="already registered as a @Schema"):
+            register_union("SUFuturesMarketOrder", SUFuturesOrderRequest)
+
+
+# -----------------------------------------------------------------------
+# First-class generator string assertions
+# -----------------------------------------------------------------------
+
+
+class TestRootUnionEmit:
+    def setup_method(self):
+        _register_fixtures()
+        self.schemas = {s.name: s for s in SchemaParser().parse_all_schemas()}
+
+    def _ru(self):
+        return self.schemas["SUFuturesOrderRequest"]
+
+    def test_rust_internally_tagged_enum(self):
+        out = RustGenerator().generate_file(self._ru())
+        assert '#[serde(tag = "order_type")]' in out
+        assert "pub enum SUFuturesOrderRequest {" in out
+        assert "Market(SUFuturesMarketOrder)," in out
+        assert "Limit(SUFuturesLimitOrder)," in out
+        # No struct emission for the union itself.
+        assert "pub struct SUFuturesOrderRequest" not in out
+
+    def test_zod_discriminated_union(self):
+        out = ZodGenerator().generate_file(self._ru())
+        assert (
+            "export const SUFuturesOrderRequestSchema = "
+            'z.discriminatedUnion("order_type", '
+            "[SUFuturesMarketOrderSchema, SUFuturesLimitOrderSchema]);" in out
+        )
+        assert "z.union([" not in out
+        assert (
+            "import { SUFuturesMarketOrderSchema } from './sufuturesmarketorder';"
+            in out
+        )
+
+    def test_jsonschema_oneof_plus_discriminator(self):
+        doc = json.loads(JsonSchemaGenerator().generate_file(self._ru()))
+        assert doc["title"] == "SUFuturesOrderRequest"
+        assert doc["discriminator"] == {"propertyName": "order_type"}
+        refs = {item["$ref"] for item in doc["oneOf"]}
+        assert refs == {
+            "sufuturesmarketorder.json#/$defs/SUFuturesMarketOrder",
+            "sufutureslimitorder.json#/$defs/SUFuturesLimitOrder",
+        }
+        assert "$defs" not in doc  # standalone union is not a struct collection
+
+    def test_pydantic_alias(self):
+        out = PydanticGenerator().generate_file(self._ru())
+        assert "from .sufuturesmarketorder_models import SUFuturesMarketOrder" in out
+        assert "from .sufutureslimitorder_models import SUFuturesLimitOrder" in out
+        assert "SUFuturesOrderRequest = Annotated[" in out
+        assert 'Field(discriminator="order_type")' in out
+        assert "class SUFuturesOrderRequest" not in out  # alias, not a model
+
+
+# -----------------------------------------------------------------------
+# Engine: non-supporting targets skip the union (no misleading struct)
+# -----------------------------------------------------------------------
+
+
+class TestEngineSkipsUnsupportedTargets:
+    def setup_method(self):
+        _register_fixtures()
+
+    def test_dataclasses_target_skips_union(self, tmp_path: Path):
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        cfg = Config(
+            input_dir=str(out_dir / "in"),
+            output_dir=str(out_dir),
+            targets=["dataclasses"],
+        )
+        SchemaGenerationEngine(cfg).generate_all()
+        files = {p.name for p in (out_dir / "dataclasses").glob("*.py")}
+        # Variant structs emit; the union does NOT (no self-named-field class).
+        assert "sufuturesmarketorder_models.py" in files
+        assert "sufuturesorderrequest_models.py" not in files
+
+    def test_rust_target_emits_union(self, tmp_path: Path):
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        cfg = Config(
+            input_dir=str(out_dir / "in"),
+            output_dir=str(out_dir),
+            targets=["rust"],
+        )
+        SchemaGenerationEngine(cfg).generate_all()
+        files = {p.name for p in (out_dir / "rust").glob("*.rs")}
+        assert "su_futures_order_request.rs" in files
+
+
+# -----------------------------------------------------------------------
+# Pydantic round-trip (always runs) — the alias validates via TypeAdapter
+# -----------------------------------------------------------------------
+
+
+class TestPydanticRoundTrip:
+    def setup_method(self):
+        _register_fixtures()
+
+    def teardown_method(self):
+        prefix = getattr(self, "_pkg_prefix", None)
+        if prefix:
+            for key in [k for k in sys.modules if k.startswith(prefix)]:
+                sys.modules.pop(key, None)
+
+    def _load_union(self, tmp_path: Path):
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        cfg = Config(
+            input_dir=str(out_dir / "in"),
+            output_dir=str(out_dir),
+            targets=["pydantic"],
+        )
+        SchemaGenerationEngine(cfg).generate_all()
+        pydantic_dir = out_dir / "pydantic"
+        pkg_name = "_su_pydantic_pkg"
+        pkg_spec = importlib.util.spec_from_file_location(
+            pkg_name,
+            pydantic_dir / "__init__.py",
+            submodule_search_locations=[str(pydantic_dir)],
+        )
+        pkg_mod = importlib.util.module_from_spec(pkg_spec)
+        sys.modules[pkg_name] = pkg_mod
+        self._pkg_prefix = pkg_name
+        pkg_spec.loader.exec_module(pkg_mod)
+        return pkg_mod.SUFuturesOrderRequest
+
+    @pytest.mark.parametrize("wire", WIRE_PAYLOADS)
+    def test_pydantic_typeadapter_roundtrip(self, tmp_path: Path, wire: dict):
+        from pydantic import TypeAdapter
+
+        union_alias = self._load_union(tmp_path)
+        adapter = TypeAdapter(union_alias)
+        obj = adapter.validate_python(wire)
+        emitted = json.loads(adapter.dump_json(obj))
+        assert _canonical(emitted) == _canonical(wire)
+
+
+# -----------------------------------------------------------------------
+# Rust round-trip — compile a tiny harness, deserialize + re-serialize
+# -----------------------------------------------------------------------
+
+_RUST_MAIN = r"""
+use generated::SUFuturesOrderRequest;
+use std::io::Read;
+
+fn main() {
+    let mut input = String::new();
+    std::io::stdin().read_to_string(&mut input).unwrap();
+    for line in input.lines().filter(|l| !l.trim().is_empty()) {
+        let parsed: SUFuturesOrderRequest = serde_json::from_str(line).unwrap();
+        let out = serde_json::to_string(&parsed).unwrap();
+        println!("{}", out);
+    }
+}
+"""
+
+
+@pytest.mark.skipif(not shutil.which("cargo"), reason="cargo not installed")
+def test_rust_roundtrip(tmp_path: Path):
+    _register_fixtures()
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    cfg = Config(
+        input_dir=str(out_dir / "in"),
+        output_dir=str(out_dir),
+        targets=["rust"],
+    )
+    SchemaGenerationEngine(cfg).generate_all()
+    rust_dir = out_dir / "rust"
+
+    crate = tmp_path / "rt_crate"
+    src = crate / "src"
+    src.mkdir(parents=True)
+    for rs in rust_dir.glob("*.rs"):
+        shutil.copy(rs, src / rs.name)
+    (src / "main.rs").write_text(_RUST_MAIN)
+
+    (crate / "Cargo.toml").write_text(
+        "[package]\n"
+        'name = "generated"\n'
+        'version = "0.0.0"\n'
+        'edition = "2021"\n\n'
+        "[dependencies]\n"
+        'serde = { version = "1", features = ["derive"] }\n'
+        'serde_json = "1"\n'
+        'schemars = "0.8"\n\n'
+        "[[bin]]\n"
+        'name = "rt"\n'
+        'path = "src/main.rs"\n'
+    )
+
+    payload = "\n".join(json.dumps(p) for p in WIRE_PAYLOADS)
+    result = subprocess.run(
+        ["cargo", "run", "--quiet", "--bin", "rt"],
+        cwd=crate,
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, (
+        f"cargo run failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    assert len(lines) == len(WIRE_PAYLOADS)
+    for emitted_line, wire in zip(lines, WIRE_PAYLOADS, strict=True):
+        assert _canonical(json.loads(emitted_line)) == _canonical(wire)
+
+
+# -----------------------------------------------------------------------
+# Zod round-trip — parse + re-serialize via a compiled-then-run TS harness
+# -----------------------------------------------------------------------
+
+_ZOD_HARNESS = """
+import {{ SUFuturesOrderRequestSchema }} from "./sufuturesorderrequest";
+
+const payloads = {payloads};
+const out = payloads.map((p: unknown) => SUFuturesOrderRequestSchema.parse(p));
+process.stdout.write(JSON.stringify(out));
+"""
+
+
+@pytest.mark.skipif(not shutil.which("npx"), reason="npx not installed")
+def test_zod_roundtrip(tmp_path: Path):
+    _register_fixtures()
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    cfg = Config(
+        input_dir=str(out_dir / "in"),
+        output_dir=str(out_dir),
+        targets=["zod"],
+    )
+    SchemaGenerationEngine(cfg).generate_all()
+    zod_dir = out_dir / "zod"
+
+    (zod_dir / "harness.ts").write_text(
+        _ZOD_HARNESS.format(payloads=json.dumps(WIRE_PAYLOADS))
+    )
+
+    if (
+        subprocess.run(
+            ["npm", "init", "-y"],
+            cwd=zod_dir,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        ).returncode
+        != 0
+    ):
+        pytest.skip("npm init failed")
+
+    install = subprocess.run(
+        ["npm", "install", "zod", "typescript", "tsx"],
+        cwd=zod_dir,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if install.returncode != 0:
+        pytest.skip(f"npm install failed: {install.stderr}")
+
+    result = subprocess.run(
+        ["npx", "tsx", "harness.ts"],
+        cwd=zod_dir,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"zod harness failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+    parsed = json.loads(result.stdout)
+    assert len(parsed) == len(WIRE_PAYLOADS)
+    for emitted, wire in zip(parsed, WIRE_PAYLOADS, strict=True):
+        assert _canonical(emitted) == _canonical(wire)


### PR DESCRIPTION
## Summary
Closes #131.

schema-gen previously discovered discriminated unions **only at field-use sites** — a union had to be a field on a `@Schema`, and the emitted enum was named `container+field`. A top-level union alias used as a field nowhere (e.g. a wire type like `FuturesOrderRequest`) registered nothing and generated in no target.

This adds a new public API:

```python
from typing import Annotated, Union
from schema_gen import Field, register_union

FuturesOrderRequest = register_union(
    "FuturesOrderRequest",
    Annotated[
        Union[FuturesMarketOrder, FuturesLimitOrder],
        Field(discriminator="order_type"),
    ],
)
```

It emits a **real tagged union named after the alias** across the four targets that can express one:

| Target | Output |
|---|---|
| Rust | `#[serde(tag = "...")]` internally-tagged enum |
| Pydantic v2 | module-level `Annotated[Union, Field(discriminator=...)]` alias (real variant imports → usable via `TypeAdapter`) |
| Zod | `export const … = z.discriminatedUnion("…", [...])` |
| JSON Schema | top-level `oneOf` + OpenAPI-style `discriminator` document |

## Design
- Reuses the existing field-level machinery: `parse_union` builds the union `USRField` via `create_usr_field_from_python` and resolves tags via `_resolve_discriminator_tags`; `USRSchema` gains `is_root_union` + `root_union_field`; variant structs' `Literal` tag fields are serde-skipped by the same `_mark_discriminator_tag_fields` post-pass.
- `register_union` returns the alias unchanged (stays usable as a type hint) and **rejects a name colliding** with a `@Schema` (and vice-versa).
- Generators that can't express a tagged union (`sqlalchemy`, `dataclasses`, `typeddict`, `avro`, `protobuf`, `graphql`, `kotlin`, `jackson`, `pathway`) declare `supports_root_union = False`; the **engine skips** root-union schemas for them with a warning, rather than emitting a misleading struct with one self-named field.
- Registry index renders them as `kind: "discriminated_union"`.

## Testing
- New `tests/test_standalone_union.py` (15 tests): parser accept/reject + name-collision, per-generator emit assertions, engine skip/emit, and **cross-language round-trips proven by execution** — real `cargo run` (Rust), `TypeAdapter` (Pydantic), and `tsx` (Zod) — plus JSON Schema structure assertions.
- `tests/conftest.py` autouse fixture clears the process-global `_unions` registry between tests (most tests only cleared `_schemas`).
- Full suite: **528 passed, 5 skipped**; ruff clean; `validate_all_formats` 100%; in-container docker validation green.
- Pre-push local `code-reviewer` subagent: **approved (READY TO PUSH)**; its two recommendations applied (direct attribute access over defensive `getattr`; name-collision guards). Codex CLI rate-limited (resets Jun 4) — relying on the GitHub-side Codex Stage 2.

## Note on overlap with #132 (#130)
This branch includes the **same one-line `Dockerfile.validation` 3.14→3.12 fix** as PR #132, solely to keep the local `docker-validation` pre-commit gate green here (the package `requires-python` is `>=3.12,<3.13`). git resolves the duplicate on merge; whichever PR lands second sees a no-op for that line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)