### PR TITLE
chore: bump version to 0.4.1 (published to Nexus)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "schema-gen"
-version = "0.4.0"
+version = "0.4.1"
 description = "Universal schema converter - define once, generate everywhere"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1308,7 +1308,7 @@ wheels = [
 
 [[package]]
 name = "schema-gen"
-version = "0.3.22"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
build.sh auto-bumped patch when publishing the pathway-free wheel to Nexus. Syncs main to the published version.