### PR TITLE
feat: Add Zod 4 support - update z.record() API

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -214,8 +214,8 @@ config = Config(
 | `bool` | `z.boolean()` |
 | `datetime` | `z.string().datetime()` |
 | `list[T]` | `z.array(<zod_type>)` |
-| `dict[str, T]` | `z.record(<zod_type>)` |
-| `dict[str, Any]` | `z.record(z.any())` |
+| `dict[str, T]` | `z.record(z.string(), <zod_type>)` |
+| `dict[str, Any]` | `z.record(z.string(), z.any())` |
 | `Optional[T]` | `<zod_type>.optional()` |
 | `Literal["a"]` | `z.literal("a")` |
 | Nested `@Schema` | `SchemaNameSchema` (cross-file import) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,8 @@ dev = [
     "pymdown-extensions>=10.21.3",  # Security: CVE-2026-46338
     "pytest>=8.4.2",
     "pytest-cov>=6.3.0",
+    "ruff>=0.9",
+    "mypy>=1.14",
     "setuptools<83",  # Pin setuptools to avoid pkg_resources deprecation warnings
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "schema-gen"
-version = "0.4.1"
+version = "0.5.0"
 description = "Universal schema converter - define once, generate everywhere"
 readme = "README.md"
 authors = [

--- a/src/schema_gen/generators/zod_generator.py
+++ b/src/schema_gen/generators/zod_generator.py
@@ -445,8 +445,8 @@ class ZodGenerator(BaseGenerator):
         elif field.type == FieldType.DICT:
             if field.inner_type is not None:
                 value_zod_type = self._get_zod_type(field.inner_type)
-                return f"z.record({value_zod_type})"
-            return "z.record(z.any())"
+                return f"z.record(z.string(), {value_zod_type})"
+            return "z.record(z.string(), z.any())"
 
         elif field.type == FieldType.UNION:
             if field.union_types:

--- a/tests/golden_outputs/zod_canonical_order.ts
+++ b/tests/golden_outputs/zod_canonical_order.ts
@@ -28,7 +28,7 @@ export const CanonicalOrderSchema = z.object({
   price: z.number(), // Limit price
   side: CanonicalSideSchema, // Buy or sell
   tag: z.string().optional(), // Optional client tag
-  metadata: z.record(z.any()), // Free-form metadata
+  metadata: z.record(z.string(), z.any()), // Free-form metadata
   fills: z.array(z.number()), // Per-fill prices (FIFO)
 });
 

--- a/tests/test_zod_dict_imports.py
+++ b/tests/test_zod_dict_imports.py
@@ -51,7 +51,7 @@ class TestZodDictValueTypes:
     """Fix #67: dict[str, T] must use T's Zod type, not z.any()."""
 
     def test_dict_nested_schema_generates_record_with_schema_ref(self, tmp_path):
-        """dict[str, NestedSchema] -> z.record(NestedSchemaSchema) with import."""
+        """dict[str, NestedSchema] -> z.record(z.string(), NestedSchemaSchema) with import."""
         _reregister(_DictNested, _DictNestedParent)
 
         out_dir = tmp_path / "out"
@@ -63,11 +63,11 @@ class TestZodDictValueTypes:
         SchemaGenerationEngine(config).generate_all()
 
         parent_ts = (out_dir / "zod" / "_dictnestedparent.ts").read_text()
-        assert "z.record(_DictNestedSchema)" in parent_ts
+        assert "z.record(z.string(), _DictNestedSchema)" in parent_ts
         assert "import { _DictNestedSchema } from './_dictnested';" in parent_ts
 
     def test_dict_str_generates_record_with_string(self, tmp_path):
-        """dict[str, str] -> z.record(z.string())."""
+        """dict[str, str] -> z.record(z.string(), z.string())."""
         _reregister(_DictStrParent)
 
         out_dir = tmp_path / "out"
@@ -79,10 +79,10 @@ class TestZodDictValueTypes:
         SchemaGenerationEngine(config).generate_all()
 
         parent_ts = (out_dir / "zod" / "_dictstrparent.ts").read_text()
-        assert "z.record(z.string())" in parent_ts
+        assert "z.record(z.string(), z.string())" in parent_ts
 
     def test_dict_any_generates_record_with_any_no_unused_imports(self, tmp_path):
-        """dict[str, Any] -> z.record(z.any()) with no unused imports."""
+        """dict[str, Any] -> z.record(z.string(), z.any()) with no unused imports."""
         _reregister(_DictAnyParent)
 
         out_dir = tmp_path / "out"
@@ -94,12 +94,12 @@ class TestZodDictValueTypes:
         SchemaGenerationEngine(config).generate_all()
 
         parent_ts = (out_dir / "zod" / "_dictanyparent.ts").read_text()
-        assert "z.record(z.any())" in parent_ts
+        assert "z.record(z.string(), z.any())" in parent_ts
         # No cross-file imports should exist (only 'import { z } from "zod"').
         assert parent_ts.count("import ") == 1
 
     def test_optional_dict_nested_appends_optional(self, tmp_path):
-        """Optional[dict[str, NestedSchema]] -> z.record(...).optional()."""
+        """Optional[dict[str, NestedSchema]] -> z.record(z.string(), ...).optional()."""
         _reregister(_DictNested, _DictOptionalNestedParent)
 
         out_dir = tmp_path / "out"
@@ -111,11 +111,11 @@ class TestZodDictValueTypes:
         SchemaGenerationEngine(config).generate_all()
 
         parent_ts = (out_dir / "zod" / "_dictoptionalnestedparent.ts").read_text()
-        assert "z.record(_DictNestedSchema).optional()" in parent_ts
+        assert "z.record(z.string(), _DictNestedSchema).optional()" in parent_ts
         assert "import { _DictNestedSchema } from './_dictnested';" in parent_ts
 
     def test_dict_list_nested_generates_record_with_array(self, tmp_path):
-        """dict[str, list[NestedSchema]] -> z.record(z.array(NestedSchemaSchema))."""
+        """dict[str, list[NestedSchema]] -> z.record(z.string(), z.array(NestedSchemaSchema))."""
         _reregister(_DictNested, _DictListNestedParent)
 
         out_dir = tmp_path / "out"
@@ -127,11 +127,11 @@ class TestZodDictValueTypes:
         SchemaGenerationEngine(config).generate_all()
 
         parent_ts = (out_dir / "zod" / "_dictlistnestedparent.ts").read_text()
-        assert "z.record(z.array(_DictNestedSchema))" in parent_ts
+        assert "z.record(z.string(), z.array(_DictNestedSchema))" in parent_ts
         assert "import { _DictNestedSchema } from './_dictnested';" in parent_ts
 
     def test_self_referential_dict_uses_lazy(self):
-        """dict[str, Self] -> z.record(z.lazy(() => SelfSchema))."""
+        """dict[str, Self] -> z.record(z.string(), z.lazy(() => SelfSchema))."""
         schema = USRSchema(
             name="TreeNode",
             fields=[
@@ -150,4 +150,4 @@ class TestZodDictValueTypes:
             ],
         )
         out = ZodGenerator().generate_file(schema)
-        assert "z.record(z.lazy(() => TreeNodeSchema))" in out
+        assert "z.record(z.string(), z.lazy(() => TreeNodeSchema))" in out

--- a/uv.lock
+++ b/uv.lock
@@ -7,9 +7,6 @@ resolution-markers = [
     "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
-[options]
-exclude-newer = "2026-07-11T23:09:50Z"
-
 [manifest]
 constraints = [
     { name = "aiohttp", specifier = ">=3.14.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-04T23:24:43Z"
+exclude-newer = "2026-07-11T23:09:50Z"
 
 [manifest]
 constraints = [
@@ -1308,7 +1308,7 @@ wheels = [
 
 [[package]]
 name = "schema-gen"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -1376,9 +1376,11 @@ dev = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "mypy" },
     { name = "pymdown-extensions" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "ruff" },
     { name = "setuptools" },
 ]
 
@@ -1418,9 +1420,11 @@ dev = [
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", specifier = ">=9.6.18" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.30.0" },
+    { name = "mypy", specifier = ">=1.14" },
     { name = "pymdown-extensions", specifier = ">=10.21.3" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-cov", specifier = ">=6.3.0" },
+    { name = "ruff", specifier = ">=0.9" },
     { name = "setuptools", specifier = "<83" },
 ]
 


### PR DESCRIPTION
## Summary
Adds Zod 4 compatibility by updating the `z.record()` API to require both key and value types.

## Breaking Change
Zod 4 changed `z.record()` signature from 1 argument to 2-3 arguments. The key type must now be explicitly specified.

## Changes
- Update `z.record(valueType)` → `z.record(z.string(), valueType)`
- Update all tests to match new API
- Update documentation with new signature examples
- Bump version to 0.5.0
- Published to Nexus

## Migration Path
1. Upgrade to schema-gen 0.5.0
2. Regenerate contracts
3. Upgrade frontend to Zod 4

## Testing
- ✅ All Zod tests pass
- ✅ Published wheel 0.5.0 to Nexus
- Ready for tradingcore-contracts regeneration

Closes #(no issue yet - created proactively for trading-platform#432 dependency chain)