### PR TITLE
fix: Regenerate uv.lock to fix main branch CI

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-04T23:24:43Z"
+exclude-newer = "2026-07-11T23:09:50Z"
 
 [manifest]
 constraints = [


### PR DESCRIPTION
Fixes the red build badge on main branch.

**Problem**: The lockfile consistency check has been failing since July 12 due to UV_EXCLUDE_NEWER environment changes.

**Fix**: Regenerated uv.lock with `uv lock` to match current CI environment.

This is a clean lockfile update with no functional changes - just syncing with the CI environment's timestamp changes.